### PR TITLE
import: allow skipping members

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -199,7 +199,10 @@ func importTeams(ctx context.Context, provider pager.Pager, fh *firehydrant.Clie
 	console.Successf("Found %d teams on FireHydrant.\n", len(fhTeams))
 
 	if err := provider.LoadTeamMembers(ctx); err != nil {
-		return fmt.Errorf("unable to populate team members: %w", err)
+		console.Errorf("unable to load team members: %s", err.Error())
+		if y, yErr := console.YesNo("Continue without team members?"); yErr != nil || !y {
+			return fmt.Errorf("unable to populate team members: %w", err)
+		}
 	}
 
 	// First, we prompt users which teams to import to FireHydrant from the external provider.

--- a/console/select.go
+++ b/console/select.go
@@ -72,3 +72,11 @@ func MultiSelectf[T any](options []T, toString func(T) string, title string, arg
 
 	return values, selected, nil
 }
+
+func YesNo(title string, args ...any) (bool, error) {
+	response, _, err := Selectf([]string{"Yes", "No"}, func(s string) string { return s }, title, args...)
+	if err != nil {
+		return false, fmt.Errorf("selecting yes/no: %w", err)
+	}
+	return response == 0, nil
+}


### PR DESCRIPTION
Don't hard fail on failure to import members, so we don't prevent users from importing other things until #27 is addressed.