### PR TITLE
pager: fixup victorops

### DIFF
--- a/pager/pager_test.go
+++ b/pager/pager_test.go
@@ -48,9 +48,13 @@ func pagerProviderHttpServer(t *testing.T) *httptest.Server {
 			t.Fatalf("error joining path for expected response: %s", err)
 		}
 		if _, err := os.Stat(filename); err != nil {
-			t.Logf("file not found: %s", filename)
-			http.NotFound(w, r)
-			return
+			t.Logf("file not found: %s, pre-creating file with empty JSON", filename)
+			if f, err := os.OpenFile(filename, os.O_CREATE, 0644); err != nil {
+				t.Fatalf("error creating file: %s", err)
+			} else {
+				_, _ = f.WriteString("{}")
+				_ = f.Close()
+			}
 		}
 		http.ServeFile(w, r, filename)
 	})

--- a/pager/testdata/TestVictorOps/LoadTeamMembers.golden.json
+++ b/pager/testdata/TestVictorOps/LoadTeamMembers.golden.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ext_team": {
+      "id": "team-rocket",
+      "name": "TeamRocket",
+      "slug": "team-rocket",
+      "fh_team_id": {
+        "String": "",
+        "Valid": false
+      },
+      "is_group": 0,
+      "to_import": 0,
+      "annotations": "https://example.com [Default Team]"
+    },
+    "ext_user": {
+      "id": "johndoe",
+      "name": "John Doe",
+      "email": "jdoe@example.com",
+      "fh_user_id": {
+        "String": "",
+        "Valid": false
+      },
+      "annotations": "https://example.com/me"
+    }
+  }
+]

--- a/pager/testdata/TestVictorOps/LoadTeams.golden.json
+++ b/pager/testdata/TestVictorOps/LoadTeams.golden.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "team-rocket",
+    "name": "TeamRocket",
+    "slug": "team-rocket",
+    "fh_team_id": {
+      "String": "",
+      "Valid": false
+    },
+    "is_group": 0,
+    "to_import": 0,
+    "annotations": "https://example.com [Default Team]"
+  }
+]

--- a/pager/testdata/TestVictorOps/LoadUsers.golden.json
+++ b/pager/testdata/TestVictorOps/LoadUsers.golden.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "johndoe",
+    "name": "John Doe",
+    "email": "jdoe@example.com",
+    "fh_user_id": {
+      "String": "",
+      "Valid": false
+    },
+    "annotations": "https://example.com/me"
+  }
+]

--- a/pager/testdata/TestVictorOps/apiserver/api-public-v1-team-team-rocket-members.json
+++ b/pager/testdata/TestVictorOps/apiserver/api-public-v1-team-team-rocket-members.json
@@ -1,0 +1,13 @@
+{
+  "_selfUrl": "https://example.com/members",
+  "_teamUrl": "https://example.com/teams/1",
+  "members": [
+    {
+      "username": "johndoe",
+      "firstName": "John",
+      "lastName": "Doe",
+      "version": 0,
+      "verified": true
+    }
+  ]
+}

--- a/pager/testdata/TestVictorOps/apiserver/api-public-v1-team.json
+++ b/pager/testdata/TestVictorOps/apiserver/api-public-v1-team.json
@@ -1,0 +1,14 @@
+[
+  {
+    "_selfUrl": "https://example.com",
+    "_membersUrl": "https://example.com/members",
+    "_policiesUrl": "https://example.com/policies",
+    "_adminsUrl": "https://example.com/admins",
+    "name": "TeamRocket",
+    "slug": "team-rocket",
+    "memberCount": 1,
+    "version": 0,
+    "isDefaultTeam": true,
+    "description": "Team Rocket responds to every on-call!"
+  }
+]

--- a/pager/testdata/TestVictorOps/apiserver/api-public-v2-user.json
+++ b/pager/testdata/TestVictorOps/apiserver/api-public-v2-user.json
@@ -1,0 +1,15 @@
+{
+  "users": [
+    {
+      "firstName": "John",
+      "lastName": "Doe",
+      "username": "johndoe",
+      "email": "jdoe@example.com",
+      "createdAt": "2024-05-02T17:12:35Z",
+      "passwordLastUpdated": "2024-05-02T17:12:35Z",
+      "verified": true,
+      "_selfUrl": "https://example.com/me"
+    }
+  ],
+  "_selfUrl": "https://example.com/me"
+}

--- a/pager/victorops.go
+++ b/pager/victorops.go
@@ -2,11 +2,11 @@ package pager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/firehydrant/signals-migrator/console"
 	"github.com/firehydrant/signals-migrator/store"
-	"github.com/gosimple/slug"
 	"github.com/victorops/go-victorops/victorops"
 )
 
@@ -15,8 +15,12 @@ type VictorOps struct {
 }
 
 func NewVictorOps(apiKey string, appId string) *VictorOps {
+	return NewVictorOpsWithURL(apiKey, appId, "https://api.victorops.com")
+}
+
+func NewVictorOpsWithURL(apiKey string, appId string, url string) *VictorOps {
 	return &VictorOps{
-		client: victorops.NewClient(appId, apiKey, "https://api.victorops.com"),
+		client: victorops.NewClient(appId, apiKey, url),
 	}
 }
 
@@ -37,16 +41,38 @@ func (v *VictorOps) Teams(ctx context.Context) ([]store.ExtTeam, error) {
 }
 
 func (v *VictorOps) LoadUsers(ctx context.Context) error {
-	vusers, _, err := v.client.GetAllUserV2()
+	type User struct {
+		FirstName string `json:"firstName,omitempty"`
+		LastName  string `json:"lastName,omitempty"`
+		Username  string `json:"username,omitempty"`
+		Email     string `json:"email,omitempty"`
+		Admin     bool   `json:"admin,omitempty"`
+		SelfURL   string `json:"_selfUrl,omitempty"`
+	}
+	type Users struct {
+		Users []User `json:"users,omitempty"`
+	}
+
+	_, details, err := v.client.GetAllUserV2()
 	if err != nil {
 		return fmt.Errorf("querying victorops: %w", err)
 	}
+	var users Users
+	if err := json.Unmarshal([]byte(details.ResponseBody), &users); err != nil {
+		return fmt.Errorf("unmarshalling victorops users: %w", err)
+	}
 
-	for _, user := range vusers.Users {
+	for _, user := range users.Users {
+		annotations := user.SelfURL
+		if user.Admin {
+			annotations += " [Admin]"
+		}
 		if err := store.UseQueries(ctx).InsertExtUser(ctx, store.InsertExtUserParams{
 			ID:    user.Username,
 			Email: user.Email,
 			Name:  user.FirstName + " " + user.LastName,
+
+			Annotations: annotations,
 		}); err != nil {
 			return fmt.Errorf("saving user to db: %w", err)
 		}
@@ -56,17 +82,33 @@ func (v *VictorOps) LoadUsers(ctx context.Context) error {
 }
 
 func (v *VictorOps) LoadTeams(ctx context.Context) error {
-	vteams, _, err := v.client.GetAllTeams()
+	type Team struct {
+		Name          string `json:"name,omitempty"`
+		Slug          string `json:"slug,omitempty"`
+		IsDefaultTeam bool   `json:"isDefaultTeam,omitempty"`
+		SelfURL       string `json:"_selfUrl,omitempty"`
+	}
+
+	_, details, err := v.client.GetAllTeams()
 	if err != nil {
 		return fmt.Errorf("querying victorops: %w", err)
 	}
+	var vteams []Team
+	if err := json.Unmarshal([]byte(details.ResponseBody), &vteams); err != nil {
+		return fmt.Errorf("unmarshalling victorops teams: %w", err)
+	}
 
-	for _, team := range *vteams {
-		tSlug := slug.Make(team.Name)
+	for _, team := range vteams {
+		annotations := team.SelfURL
+		if team.IsDefaultTeam {
+			annotations += " [Default Team]"
+		}
 		if err := store.UseQueries(ctx).InsertExtTeam(ctx, store.InsertExtTeamParams{
-			ID:   tSlug,
-			Slug: tSlug,
+			ID:   team.Slug,
+			Slug: team.Slug,
 			Name: team.Name,
+
+			Annotations: annotations,
 		}); err != nil {
 			return fmt.Errorf("saving team to db: %w", err)
 		}
@@ -75,7 +117,25 @@ func (v *VictorOps) LoadTeams(ctx context.Context) error {
 }
 
 func (v *VictorOps) LoadTeamMembers(ctx context.Context) error {
-	console.Warnf("victorops.LoadTeamMembers is not currently supported.")
+	q := store.UseQueries(ctx)
+	teams, err := q.ListTeams(ctx)
+	if err != nil {
+		return fmt.Errorf("loading teams: %w", err)
+	}
+	for _, team := range teams {
+		vteam, _, err := v.client.GetTeamMembers(team.ID)
+		if err != nil {
+			return fmt.Errorf("querying victorops: %w", err)
+		}
+		for _, member := range vteam.Members {
+			if err := q.InsertExtMembership(ctx, store.InsertExtMembershipParams{
+				TeamID: team.ID,
+				UserID: member.Username,
+			}); err != nil {
+				return fmt.Errorf("saving team member to db: %w", err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/pager/victorops_test.go
+++ b/pager/victorops_test.go
@@ -1,0 +1,67 @@
+package pager_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/firehydrant/signals-migrator/pager"
+	"github.com/firehydrant/signals-migrator/store"
+)
+
+func TestVictorOps(t *testing.T) {
+	// Avoid sharing setup code between tests to prevent test pollution in parallel execution.
+	setup := func(t *testing.T) (context.Context, pager.Pager) {
+		ctx := withTestDB(t)
+		ts := pagerProviderHttpServer(t)
+		vo := pager.NewVictorOpsWithURL("api-key-very-secret", "app-id-maybe-secret", ts.URL)
+		return ctx, vo
+	}
+
+	t.Run("LoadUsers", func(t *testing.T) {
+		t.Parallel()
+		ctx, vo := setup(t)
+
+		if err := vo.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		u, err := store.UseQueries(ctx).ListExtUsers(ctx)
+		if err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		assertJSON(t, u)
+	})
+
+	t.Run("LoadTeams", func(t *testing.T) {
+		t.Parallel()
+		ctx, vo := setup(t)
+
+		if err := vo.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		teams, err := store.UseQueries(ctx).ListExtTeams(ctx)
+		if err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		assertJSON(t, teams)
+	})
+
+	t.Run("LoadTeamMembers", func(t *testing.T) {
+		t.Parallel()
+		ctx, vo := setup(t)
+
+		if err := vo.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		if err := vo.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		if err := vo.LoadTeamMembers(ctx); err != nil {
+			t.Fatalf("error loading team members: %s", err)
+		}
+		members, err := store.UseQueries(ctx).ListExtTeamMemberships(ctx)
+		if err != nil {
+			t.Fatalf("error loading team members: %s", err)
+		}
+		assertJSON(t, members)
+	})
+}


### PR DESCRIPTION
Followup from #23 — VictorOps membership import didn't get migrated over when we did the whole refactoring. This changeset reimplements it in new structure.