### PR TITLE
bug: tfrender now properly associates escalation policy step to oncall schedule

### DIFF
--- a/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
+++ b/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
@@ -1,0 +1,36 @@
+{
+  "escalation_policies": [
+    {
+      "id": "P6F7EI2",
+      "name": "Endeavour",
+      "description": "",
+      "team_id": {
+        "String": "",
+        "Valid": false
+      },
+      "repeat_limit": 0,
+      "repeat_interval": {
+        "String": "",
+        "Valid": false
+      },
+      "handoff_target_type": "",
+      "handoff_target_id": "",
+      "to_import": 0
+    }
+  ],
+  "escalation_policy_step_targets": [
+    {
+      "escalation_policy_step_id": "PFN10S6",
+      "target_type": "User",
+      "target_id": "P4CMCAU"
+    }
+  ],
+  "escalation_policy_steps": [
+    {
+      "id": "PFN10S6",
+      "escalation_policy_id": "P6F7EI2",
+      "position": 0,
+      "timeout": "PT1M"
+    }
+  ]
+}

--- a/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy_seed.sql
+++ b/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy_seed.sql
@@ -25,6 +25,6 @@ INSERT INTO ext_escalation_policy_steps VALUES('PKQDFZH','P2D2WR1',0,'PT30M');
 INSERT INTO ext_escalation_policy_steps VALUES('P08T67P','PS6ITO0',0,'PT30M');
 
 INSERT INTO ext_escalation_policy_step_targets VALUES('P08T67P','User','PXI6XNI');
-INSERT INTO ext_escalation_policy_step_targets VALUES('PKQDFZH','OnCallSchedule','PGR96WL-PR3J6XJ');
+INSERT INTO ext_escalation_policy_step_targets VALUES('PKQDFZH','OnCallSchedule','PGR96WL');
 
 COMMIT;


### PR DESCRIPTION
In some scenarios, we would split a schedule from existing provider to multiple schedules in FireHydrant. When that happens, the compromise we can make in escalation policy referring to those schedules is to include both in the target, with expectations that individual teams will then modify their escalation policy steps to the desired behavior.