### PR TITLE
import: fix paddings in import-all workflow

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -281,7 +281,10 @@ func importUsers(ctx context.Context, provider pager.Pager, fh *firehydrant.Clie
 	idPad := console.PadStrings(unmatched, func(u store.ExtUser) int { return len(u.ID) })
 	emailPad := console.PadStrings(unmatched, func(u store.ExtUser) int { return len(u.Email) })
 
-	importOpts := []store.ExtUser{{ID: "[+] IMPORT ALL"}, {ID: "[<] SKIP ALL"}}
+	importOpts := []store.ExtUser{
+		{ID: "[+] IMPORT ALL"},
+		{ID: "[<] SKIP ALL  "}, // Extra spaces for padding alignment of icons
+	}
 	importOpts = append(importOpts, unmatched...)
 	selected, toImport, err := console.MultiSelectf(importOpts, func(u store.ExtUser) string {
 		return fmt.Sprintf("%*s  %-*s  %s", idPad, u.ID, emailPad, u.Email, u.Name)
@@ -311,7 +314,10 @@ func importUsers(ctx context.Context, provider pager.Pager, fh *firehydrant.Clie
 
 	namePad := console.PadStrings(fhUsers, func(u store.FhUser) int { return len(u.Name) })
 
-	matchOpts := []store.FhUser{{Name: "[+] CREATE THE REST OF USERS AS NEW"}, {Name: "[+] CREATE USER AS NEW"}}
+	matchOpts := []store.FhUser{
+		{Name: "[+] CREATE THE REST OF USERS AS NEW"},
+		{Name: "[+] CREATE USER AS NEW             "}, // Extra spaces for padding alignment of icons
+	}
 	matchOpts = append(matchOpts, fhUsers...)
 	for i, u := range toImport {
 		selected, fhUser, err := console.Selectf(matchOpts, func(u store.FhUser) string {

--- a/console/select.go
+++ b/console/select.go
@@ -3,6 +3,7 @@ package console
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 )
@@ -52,8 +53,14 @@ func MultiSelectf[T any](options []T, toString func(T) string, title string, arg
 			continue
 		}
 		Warnf("You have selected: \n")
-		for _, i := range values {
-			Warnf("  %s\n", opts[i].Key)
+		if len(values) == 1 {
+			// Don't perform padding based on list's max when it's only one value,
+			// as it would look oddly spaced out.
+			Warnf("  %s\n", strings.TrimSpace(opts[values[0]].Key))
+		} else {
+			for _, i := range values {
+				Warnf("  %s\n", opts[i].Key)
+			}
 		}
 
 		response, _, err := Selectf([]string{"Yes", "No"}, func(s string) string { return s }, "Confirm selection?")


### PR DESCRIPTION
(Blocked test emails in screenshot)

# Before

<img width="848" alt="Screenshot 2024-05-13 at 11 52 09 AM" src="https://github.com/firehydrant/signals-migrator/assets/14004487/64205cdf-71c4-49e2-a1b3-55edaca3b023">


# After

<img width="841" alt="Screenshot 2024-05-13 at 11 54 18 AM" src="https://github.com/firehydrant/signals-migrator/assets/14004487/bef928b5-1797-45e3-9005-86227c6deac6">

