### PR TITLE
pager/og: safer `teamID` retrieval

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -338,7 +338,7 @@ func importUsers(ctx context.Context, provider pager.Pager, fh *firehydrant.Clie
 		switch selected {
 		case 0:
 			console.Infof("[+] All users will be created in FireHydrant.\n")
-			for _, u := range unmatched[i:] {
+			for _, u := range toImport[i:] {
 				fhUser, err := fh.CreateUser(ctx, &u)
 				if err != nil {
 					console.Warnf("unable to create user '%s': %s\n", u.Email, err.Error())

--- a/internal/firehydrant/firehydrant.go
+++ b/internal/firehydrant/firehydrant.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/firehydrant/signals-migrator/console"
@@ -211,6 +212,8 @@ func (c *Client) CreateUser(ctx context.Context, u SCIMUser) (*store.FhUser, err
 		return nil, fmt.Errorf("creating user: %w", err)
 	}
 	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		console.Errorf("unexpected status code %d: %s\n", resp.StatusCode, body)
 		return nil, fmt.Errorf("creating user: unexpected status code %d", resp.StatusCode)
 	}
 	return c.fetchUser(ctx, u.PrimaryEmail())

--- a/pager/opsgenie.go
+++ b/pager/opsgenie.go
@@ -350,17 +350,22 @@ func (o *Opsgenie) LoadEscalationPolicies(ctx context.Context) error {
 
 func (o *Opsgenie) saveEscalationPolicyToDB(ctx context.Context, policy escalation.Escalation) error {
 	var repeatLimit int64
-	var repeatInterval sql.NullString
+	repeatInterval := sql.NullString{Valid: false}
 	if policy.Repeat != nil {
 		repeatLimit = int64(policy.Repeat.Count)
 		repeatInterval.Valid = true
 		repeatInterval.String = fmt.Sprintf("PT%dM", policy.Repeat.WaitInterval)
 	}
+	teamID := sql.NullString{}
+	if policy.OwnerTeam != nil {
+		teamID.Valid = true
+		teamID.String = policy.OwnerTeam.Id
+	}
 	ep := store.InsertExtEscalationPolicyParams{
 		ID:             policy.Id,
 		Name:           policy.Name,
 		Description:    policy.Description,
-		TeamID:         sql.NullString{Valid: true, String: policy.OwnerTeam.Id},
+		TeamID:         teamID,
 		RepeatInterval: repeatInterval,
 		RepeatLimit:    repeatLimit,
 	}


### PR DESCRIPTION
Received a user report error on this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102bf49c8]
github.com/firehydrant/signals-migrator/pager.(*Opsgenie).saveEscalationPolicyToDB(0x14000412160, {0x102f46518, 0x14000276b70}, {{0x1400016e240, 0x24}, {0x1400002b038, 0x15}, {0x0, 0x0}, {0x14000165860, ...}, ...})
	~/signals-migrator/pager/opsgenie.go:363 +0x128
github.com/firehydrant/signals-migrator/pager.(*Opsgenie).LoadEscalationPolicies(0x14000412160, {0x102f46518, 0x14000276b70})
```

Seems like Opsgenie doesn't guarantee OwnerTeam to be present.