### PR TITLE
tfrender: properly correlate schedule and team on import

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -245,6 +245,10 @@ func importTeams(ctx context.Context, provider pager.Pager, fh *firehydrant.Clie
 			return fmt.Errorf("linking team '%s' to FireHydrant: %w", t.Name, err)
 		}
 	}
+
+	if err := store.UseQueries(ctx).DeleteExtTeamUnimported(ctx); err != nil {
+		return fmt.Errorf("unable to delete unimported teams: %w", err)
+	}
 	return nil
 }
 

--- a/docs/pagerduty.md
+++ b/docs/pagerduty.md
@@ -16,3 +16,4 @@ Afterwards, run `signals-migrator import` and follow the prompts.
 ## Known limitations
 
 - While we support importing "PagerDuty Service" as "FireHydrant Team", we still require the Teams API to be accessible. If your account does not have access to the Teams API, please see [#27](https://github.com/firehydrant/signals-migrator/issues/27) and let us know what error you encountered.
+- Inactive users will have "warning" lines.

--- a/pager/testdata/TestOpsgenie/LoadEscalationPolicies.golden.json
+++ b/pager/testdata/TestOpsgenie/LoadEscalationPolicies.golden.json
@@ -14,6 +14,7 @@
     },
     "handoff_target_type": "",
     "handoff_target_id": "",
+    "annotations": "",
     "to_import": 0
   }
 ]

--- a/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
+++ b/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
@@ -15,7 +15,7 @@
       },
       "handoff_target_type": "",
       "handoff_target_id": "",
-      "annotations": "[PagerDuty]\n  Endeavour https://pdt-apidocs.pagerduty.com/escalation_policies/P6F7EI2\n  Teams: []",
+      "annotations": "[PagerDuty]\n  Endeavour https://pdt-apidocs.pagerduty.com/escalation_policies/P6F7EI2",
       "to_import": 0
     }
   ],

--- a/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
+++ b/pager/testdata/TestPagerDuty/LoadEscalationPolicies.golden.json
@@ -15,6 +15,7 @@
       },
       "handoff_target_type": "",
       "handoff_target_id": "",
+      "annotations": "[PagerDuty]\n  Endeavour https://pdt-apidocs.pagerduty.com/escalation_policies/P6F7EI2\n  Teams: []",
       "to_import": 0
     }
   ],

--- a/store/models.go
+++ b/store/models.go
@@ -17,6 +17,7 @@ type ExtEscalationPolicy struct {
 	RepeatInterval    sql.NullString `json:"repeat_interval"`
 	HandoffTargetType string         `json:"handoff_target_type"`
 	HandoffTargetID   string         `json:"handoff_target_id"`
+	Annotations       string         `json:"annotations"`
 	ToImport          int64          `json:"to_import"`
 }
 

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -78,6 +78,9 @@ WHERE id IN (
 -- name: InsertExtTeamGroup :exec
 INSERT INTO ext_team_groups (group_team_id, member_team_id) VALUES (?, ?);
 
+-- name: DeleteExtTeamUnimported :exec
+DELETE FROM ext_teams WHERE to_import = 0;
+
 -- name: LinkExtUser :exec
 UPDATE ext_users SET fh_user_id = ? WHERE id = ?;
 

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -153,8 +153,11 @@ VALUES (?, ?);
 SELECT * FROM ext_escalation_policies;
 
 -- name: InsertExtEscalationPolicy :exec
-INSERT INTO ext_escalation_policies (id, name, description, team_id, repeat_interval, repeat_limit, handoff_target_type, handoff_target_id, to_import)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO ext_escalation_policies (id, name, description, team_id, repeat_interval, repeat_limit, handoff_target_type, handoff_target_id, annotations, to_import)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- name: UpdateExtEscalationPolicyTeam :exec
+UPDATE ext_escalation_policies SET team_id = ? WHERE id = ?;
 
 -- name: MarkAllExtEscalationPolicyToImport :exec
 UPDATE ext_escalation_policies SET to_import = 1;

--- a/store/queries.sql.go
+++ b/store/queries.sql.go
@@ -19,6 +19,15 @@ func (q *Queries) DeleteExtEscalationPolicyUnimported(ctx context.Context) error
 	return err
 }
 
+const deleteExtTeamUnimported = `-- name: DeleteExtTeamUnimported :exec
+DELETE FROM ext_teams WHERE to_import = 0
+`
+
+func (q *Queries) DeleteExtTeamUnimported(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, deleteExtTeamUnimported)
+	return err
+}
+
 const deleteUnmatchedExtUsers = `-- name: DeleteUnmatchedExtUsers :exec
 DELETE FROM ext_users
 WHERE fh_user_id IS NULL

--- a/store/schema.sql
+++ b/store/schema.sql
@@ -103,6 +103,7 @@ CREATE TABLE IF NOT EXISTS ext_escalation_policies (
   repeat_interval TEXT,
   handoff_target_type TEXT NOT NULL,
   handoff_target_id TEXT NOT NULL,
+  annotations TEXT NOT NULL DEFAULT '',
   to_import INTEGER NOT NULL DEFAULT 0
 ) STRICT;
 

--- a/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy_seed.sql
+++ b/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy_seed.sql
@@ -56,7 +56,7 @@ INSERT INTO ext_schedule_members VALUES('8ab5a183-8ef5-47db-9de0-56663cfbae7c-9b
 INSERT INTO ext_schedule_members VALUES('8ab5a183-8ef5-47db-9de0-56663cfbae7c-9b488cc6-efa0-44f3-a432-b913acab9147','e94e17aa-418c-44f7-8e47-1eaebf6b5343');
 INSERT INTO ext_schedule_members VALUES('8ab5a183-8ef5-47db-9de0-56663cfbae7c-9b488cc6-efa0-44f3-a432-b913acab9147','e0a51be7-3c7e-407f-8678-292ab421f55f');
 
-INSERT INTO ext_escalation_policies VALUES('880ec24e-58db-441b-9681-2cb527bd24b2','AJ Team_escalation','','946bf740-0497-4d5d-b31f-23a6e55a2719',0,NULL,'','',1);
+INSERT INTO ext_escalation_policies VALUES('880ec24e-58db-441b-9681-2cb527bd24b2','AJ Team_escalation','','946bf740-0497-4d5d-b31f-23a6e55a2719',0,NULL,'','','',1);
 
 INSERT INTO ext_escalation_policy_steps VALUES('880ec24e-58db-441b-9681-2cb527bd24b2-0','880ec24e-58db-441b-9681-2cb527bd24b2',0,'PT1M');
 

--- a/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy.golden.tf
+++ b/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy.golden.tf
@@ -51,7 +51,7 @@ resource "firehydrant_escalation_policy" "atalice_bob_test_service_ep" {
 
     targets {
       type = "OnCallSchedule"
-      id   = firehydrant_on_call_schedule.atalice_bob_is_always_on_call_layer_1.id
+      id   = firehydrant_on_call_schedule.cowboy_coders_atalice_bob_is_always_on_call_layer_1.id
     }
   }
 

--- a/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy.golden.tf
+++ b/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy.golden.tf
@@ -34,6 +34,8 @@ resource "firehydrant_on_call_schedule" "cowboy_coders_atalice_bob_is_always_on_
   team_id     = firehydrant_team.cowboy_coders.id
   time_zone   = "America/Los_Angeles"
 
+  # [PagerDuty] team-rocket https://pdt-apidocs.pagerduty.com/service-directory/PV9JOXL
+
   member_ids = [data.firehydrant_user.alice_bob.id]
 
   strategy {

--- a/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy_seed.sql
+++ b/tfrender/testdata/TestRenderPagerDuty/EscalationPolicy_seed.sql
@@ -18,8 +18,8 @@ INSERT INTO ext_schedule_teams VALUES('PGR96WL-PR3J6XJ','PV9JOXL');
 
 INSERT INTO ext_schedule_members VALUES('PGR96WL-PR3J6XJ','PRXEEQ8');
 
-INSERT INTO ext_escalation_policies VALUES('P2D2WR1','🐴 @alice.bob Test Service-ep','',NULL,0,NULL,'','',1);
-INSERT INTO ext_escalation_policies VALUES('PS6ITO0','🐴 Notify @alice.bob','',NULL,0,NULL,'','',1);
+INSERT INTO ext_escalation_policies VALUES('P2D2WR1','🐴 @alice.bob Test Service-ep','',NULL,0,NULL,'','','',1);
+INSERT INTO ext_escalation_policies VALUES('PS6ITO0','🐴 Notify @alice.bob','',NULL,0,NULL,'','','',1);
 
 INSERT INTO ext_escalation_policy_steps VALUES('PKQDFZH','P2D2WR1',0,'PT30M');
 INSERT INTO ext_escalation_policy_steps VALUES('P08T67P','PS6ITO0',0,'PT30M');

--- a/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
+++ b/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
@@ -76,6 +76,8 @@ resource "firehydrant_on_call_schedule" "aaaa_ipv6_migration_strategy_jen_primar
   time_zone   = "America/Los_Angeles"
   start_time  = "2024-04-10T20:39:29-07:00"
 
+  # [PagerDuty] Jen https://pdt-apidocs.pagerduty.com/service-directory/PT54U20
+
   member_ids = [data.firehydrant_user.kiran.id]
 
   strategy {
@@ -97,6 +99,8 @@ resource "firehydrant_on_call_schedule" "aaaa_ipv6_migration_strategy_jen_primar
   team_id     = firehydrant_team.aaaa_ipv6_migration_strategy.id
   time_zone   = "America/Los_Angeles"
   start_time  = "2024-04-10T20:39:29-07:00"
+
+  # [PagerDuty] Jen https://pdt-apidocs.pagerduty.com/service-directory/PT54U20
 
   member_ids = [data.firehydrant_user.wong.id, data.firehydrant_user.local.id]
 
@@ -160,6 +164,8 @@ resource "firehydrant_on_call_schedule" "dunder_mifflin_scranton_jack_on_call_sc
   description = " (Layer 1)"
   team_id     = firehydrant_team.dunder_mifflin_scranton.id
   time_zone   = "America/Los_Angeles"
+
+  # [PagerDuty] Jack Team https://pdt-apidocs.pagerduty.com/service-directory/PD2F80U
 
   member_ids = [data.firehydrant_user.jack.id]
 

--- a/tfrender/tfrender.go
+++ b/tfrender/tfrender.go
@@ -108,6 +108,7 @@ func (r *TFRender) Write(ctx context.Context) error {
 	if _, err := f.Write(r.f.Bytes()); err != nil {
 		return fmt.Errorf("writing file: %w", err)
 	}
+	console.Successf("Terraform file has been written to %s\n", r.Filepath())
 
 	return nil
 }


### PR DESCRIPTION
1. There seem to be a regression when we added "import service as team", such that the on-call schedule in the escalation policy were incorrectly referenced. This is fixed by ensuring we query all the possible schedules-and-team matrix which matches the given ID.
2. When user selected partial import for teams, we properly mark `to_import` in the database, but would not delete the entries which aren't imported. This caused the rendered Terraform to show teams which should have been excluded.