### PR TITLE
tfrender: trim v-prefix when it exists

### DIFF
--- a/tfrender/tfrender.go
+++ b/tfrender/tfrender.go
@@ -46,7 +46,9 @@ func fhProviderVersion() string {
 			if versionStr != dep.Version {
 				break
 			}
-			return fmt.Sprintf("~> %s", dep.Version)
+			// Go versioning may include v-prefix, but Terraform doesn't like it.
+			v := strings.TrimPrefix(dep.Version, "v")
+			return fmt.Sprintf("~> %s", v)
 		}
 	}
 


### PR DESCRIPTION
Fixes #40 