### PR TITLE
opsgenie: skip importing escalation policy whose team isn't known

### DIFF
--- a/pager/testdata/TestOpsgenie/apiserver/v2-escalations.json
+++ b/pager/testdata/TestOpsgenie/apiserver/v2-escalations.json
@@ -1,6 +1,43 @@
 {
   "data": [
     {
+      "id": "a6feab7-936d-4829-800f-e781a96bdf1b",
+      "name": "Escalation policy from unimported team",
+      "description": "",
+      "ownerTeam": {
+        "id": "f7acbc33-9853-4150-8a4b-10156d9408c8",
+        "name": "This team is not imported"
+      },
+      "rules": [
+        {
+          "condition": "if-not-acked",
+          "notifyType": "default",
+          "delay": {
+            "timeAmount": 0,
+            "timeUnit": "minutes"
+          },
+          "recipient": {
+            "type": "user",
+            "id": "b5b92115-bfe7-43eb-8c2a-e467f2e5ddc4",
+            "username": "john.doe@opsgenie.com"
+          }
+        },
+        {
+          "condition": "if-not-acked",
+          "notifyType": "default",
+          "delay": {
+            "timeAmount": 0,
+            "timeUnit": "minutes"
+          },
+          "recipient": {
+            "type": "schedule",
+            "id": "3fee43f2-02da-49be-ab50-c88ed13aecc3",
+            "name": "Customer Success_schedule"
+          }
+        }
+      ]
+    },
+    {
       "id": "2a6feab7-936d-4829-800f-e781a96bdf1b",
       "name": "Customer Success_escalation",
       "description": "",

--- a/store/errors.go
+++ b/store/errors.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"errors"
+
+	"modernc.org/sqlite"
+	sqlitelib "modernc.org/sqlite/lib"
+)
+
+type SQLError sqlite.Error
+
+func AsSQLError(err error) (*SQLError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var e *sqlite.Error
+	if errors.As(err, &e) {
+		return (*SQLError)(e), true
+	}
+	return nil, false
+}
+
+func (e *SQLError) Error() string {
+	return (*sqlite.Error)(e).Error()
+}
+
+func (e *SQLError) Code() int {
+	return (*sqlite.Error)(e).Code()
+}
+
+func (e *SQLError) IsForeignKeyConstraint() bool {
+	return e.Code() == sqlitelib.SQLITE_CONSTRAINT_FOREIGNKEY
+}


### PR DESCRIPTION
When performing selective import of teams, we still query the escalation policies globally (in case there are escalation policies which aren't related to any team wants to be imported).

However, when an escalation policy _is_ linked to a team that isn't selected to be imported, we should just skip it because we know we don't want them. Prior this changeset, the migrator would hard fail and not allow users to continue. With this changeset, the migrator will ignore the entry and continue the progress.