### PR TITLE
Fix FOREIGN KEY constraint error when importing schedules with missing teams

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -334,9 +334,21 @@ func (p *PagerDuty) saveScheduleToDB(ctx context.Context, schedule pagerduty.Sch
 	// This means all teams associated with a schedule end up with the same users.
 	// Therefore, we can safely use the first team as the schedule owner without losing user information.
 
+	q := store.UseQueries(ctx)
+
 	teamID := ""
 	if len(schedule.Teams) > 0 {
-		teamID = schedule.Teams[0].ID // Use first team as owner - all teams would have same users anyway
+		// Find the first team that exists in ext_teams (user may have excluded some teams from import)
+		for _, t := range schedule.Teams {
+			if _, err := q.GetExtTeam(ctx, t.ID); err == nil {
+				teamID = t.ID
+				break
+			}
+		}
+		if teamID == "" {
+			console.Warnf("Schedule %q (%s) belongs to a team that isn't imported.  Skipping...\n", schedule.Name, schedule.ID)
+			return nil
+		}
 	} else {
 		console.Warnf("No teams found for schedule %s, skipping...\n", schedule.ID)
 		return nil
@@ -352,8 +364,11 @@ func (p *PagerDuty) saveScheduleToDB(ctx context.Context, schedule pagerduty.Sch
 		SourceScheduleID: schedule.ID,
 	}
 
-	q := store.UseQueries(ctx)
 	if err := q.InsertExtScheduleV2(ctx, scheduleParams); err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint") {
+			console.Warnf("Schedule %q (%s) references a missing team, skipping...\n", schedule.Name, schedule.ID)
+			return nil
+		}
 		return fmt.Errorf("saving schedule: %w", err)
 	}
 

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -264,6 +264,39 @@ func TestPagerDuty(t *testing.T) {
 		assertJSON(t, schedules)
 	})
 
+	t.Run("LoadSchedulesSkipsScheduleWithMissingTeam", func(t *testing.T) {
+		t.Parallel()
+		ctx, pd := setup(t)
+
+		if err := pd.UseTeamInterface("team"); err != nil {
+			t.Fatalf("error setting team interface: %s", err)
+		}
+		if err := pd.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		if err := pd.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+
+		// Simulate user not selecting any teams for import — delete all teams
+		if err := store.UseQueries(ctx).DeleteExtTeamUnimported(ctx); err != nil {
+			t.Fatalf("error deleting unimported teams: %s", err)
+		}
+
+		// LoadSchedules should not error — it should skip schedules whose teams are missing
+		if err := pd.LoadSchedules(ctx); err != nil {
+			t.Fatalf("expected no error loading schedules with missing teams, got: %s", err)
+		}
+
+		schedules, err := store.UseQueries(ctx).ListExtSchedulesV2(ctx)
+		if err != nil {
+			t.Fatalf("error listing schedules: %s", err)
+		}
+		if len(schedules) != 0 {
+			t.Errorf("expected 0 schedules when all teams are missing, got %d", len(schedules))
+		}
+	})
+
 	t.Run("LoadSchedulesPreservesMemberOrder", func(t *testing.T) {
 		ctx, pd := setup(t)
 


### PR DESCRIPTION
## BLUF
Fix crash when importing PagerDuty schedules whose teams were not selected for import (or were never loaded in service mode), caused by an unhandled FOREIGN KEY constraint error.

## Description
When importing schedules, `saveScheduleToDB` blindly used `schedule.Teams[0].ID` as the team reference. If that team had been deleted from `ext_teams` (because the user deselected it during the team import step), the `InsertExtScheduleV2` call would fail with `FOREIGN KEY constraint failed (787)` — and there was no error handling, so it crashed the entire import.

This also affects "service" mode, where only service-associated teams are loaded. A schedule can reference a PD team that isn't tied to any service, so the team was never in `ext_teams` to begin with.

The fix follows the existing pattern from OpsGenie (`opsgenie.go:229-232`), which already handles this gracefully:
  - Iterate through all `schedule.Teams` and use `GetExtTeam()` to find the first one that exists in the database
  - If none are found, log a warning and skip the schedule
  - Added a FK error safety net on the insert itself, matching how rotation members (`pagerduty.go:438`) and team members (`pagerduty.go:280`) already handle FK failures

Added a test (`LoadSchedulesSkipsScheduleWithMissingTeam`) that reproduces the original crash by deleting all teams before loading schedules, and verifies the import completes without error.