### PR TITLE
Fix PagerDuty schedule import: emit handoff_day for daily strategy and correct EndDay for midnight-crossing restrictions

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -472,11 +472,15 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 				end := start.Add(time.Duration(restriction.DurationSeconds) * time.Second)
 
 				dayStr := strings.ToLower(time.Weekday(day).String())
+				endDayStr := dayStr
+				if end.Day() != start.Day() {
+					endDayStr = strings.ToLower(time.Weekday((day + 1) % 7).String())
+				}
 				r := store.InsertExtRotationRestrictionParams{
 					RotationID:       layer.ID,
 					RestrictionIndex: fmt.Sprintf("%d-%d", i, day),
 					StartDay:         dayStr,
-					EndDay:           dayStr,
+					EndDay:           endDayStr,
 					StartTime:        start.Format(time.TimeOnly),
 					EndTime:          end.Format(time.TimeOnly),
 				}

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -264,6 +264,62 @@ func TestPagerDuty(t *testing.T) {
 		assertJSON(t, schedules)
 	})
 
+	t.Run("LoadSchedulesDailyRestrictionCrossingMidnight", func(t *testing.T) {
+		t.Parallel()
+		ctx, pd := setup(t)
+
+		if err := pd.UseTeamInterface("team"); err != nil {
+			t.Fatalf("error setting team interface: %s", err)
+		}
+		if err := pd.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		if err := pd.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		if err := pd.LoadSchedules(ctx); err != nil {
+			t.Fatalf("error loading schedules: %s", err)
+		}
+
+		// Layer PC1DX4O has a daily_restriction starting at 17:00:00 with duration 36000s (10h),
+		// which means it ends at 03:00:00 the NEXT day. Each restriction's EndDay should be
+		// the day after its StartDay.
+		restrictions, err := store.UseQueries(ctx).ListExtRotationRestrictions(ctx, "PC1DX4O")
+		if err != nil {
+			t.Fatalf("error loading restrictions: %s", err)
+		}
+
+		if len(restrictions) != 7 {
+			t.Fatalf("expected 7 daily restrictions (one per day), got %d", len(restrictions))
+		}
+
+		// Expected: each restriction's EndDay should be the next day
+		expectedDays := []struct{ start, end string }{
+			{"sunday", "monday"},
+			{"monday", "tuesday"},
+			{"tuesday", "wednesday"},
+			{"wednesday", "thursday"},
+			{"thursday", "friday"},
+			{"friday", "saturday"},
+			{"saturday", "sunday"},
+		}
+
+		for i, r := range restrictions {
+			if r.StartDay != expectedDays[i].start {
+				t.Errorf("restriction %d: expected StartDay %q, got %q", i, expectedDays[i].start, r.StartDay)
+			}
+			if r.EndDay != expectedDays[i].end {
+				t.Errorf("restriction %d: expected EndDay %q, got %q", i, expectedDays[i].end, r.EndDay)
+			}
+			if r.StartTime != "17:00:00" {
+				t.Errorf("restriction %d: expected StartTime 17:00:00, got %s", i, r.StartTime)
+			}
+			if r.EndTime != "03:00:00" {
+				t.Errorf("restriction %d: expected EndTime 03:00:00, got %s", i, r.EndTime)
+			}
+		}
+	})
+
 	t.Run("LoadSchedulesSkipsScheduleWithMissingTeam", func(t *testing.T) {
 		t.Parallel()
 		ctx, pd := setup(t)

--- a/tfrender/testdata/TestRenderOnCallScheduleResource.golden.tf
+++ b/tfrender/testdata/TestRenderOnCallScheduleResource.golden.tf
@@ -59,6 +59,7 @@ resource "firehydrant_on_call_schedule" "team_1_slug_schedule_0" {
 
   strategy {
     type         = "daily"
+    handoff_day  = "wednesday"
     handoff_time = "11:00"
   }
 }

--- a/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy.golden.tf
+++ b/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy.golden.tf
@@ -123,6 +123,7 @@ resource "firehydrant_rotation" "aj_team_aj_team_schedule_nighttime_rotation" {
 
   strategy {
     type         = "daily"
+    handoff_day  = "wednesday"
     handoff_time = "15:00:00"
   }
 

--- a/tfrender/testdata/TestRenderOpsgenie/TeamWithSchedules.golden.tf
+++ b/tfrender/testdata/TestRenderOpsgenie/TeamWithSchedules.golden.tf
@@ -97,6 +97,7 @@ resource "firehydrant_on_call_schedule" "wong_squad_wong_team_schedule" {
 
   strategy {
     type         = "daily"
+    handoff_day  = "monday"
     handoff_time = "08:00:00"
   }
 }
@@ -166,6 +167,7 @@ resource "firehydrant_rotation" "aj_team_aj_team_schedule_nighttime_rotation" {
 
   strategy {
     type         = "daily"
+    handoff_day  = "wednesday"
     handoff_time = "15:00:00"
   }
 

--- a/tfrender/tfrender.go
+++ b/tfrender/tfrender.go
@@ -444,7 +444,7 @@ func renderRotationData(ctx context.Context, rotation store.ExtRotation, r *TFRe
 	body.AppendNewline()
 	strategy := body.AppendNewBlock("strategy", []string{}).Body()
 	strategy.SetAttributeValue("type", cty.StringVal(rotation.Strategy))
-	if rotation.Strategy == "weekly" {
+	if rotation.Strategy == "weekly" || rotation.Strategy == "daily" {
 		strategy.SetAttributeValue("handoff_day", cty.StringVal(rotation.HandoffDay))
 	}
 	if rotation.Strategy == "custom" {


### PR DESCRIPTION
## Bluf
Fixes two bugs in PagerDuty schedule import that caused strategy[handoff_day] does not have a valid value and restrictions cannot overlap errors when applying Terraform for complex schedules.

## Description
When importing PagerDuty schedules with daily strategy rotations or daily restrictions that cross midnight, the migrator produced invalid Terraform that the FireHydrant API rejected.

Bug 1: Missing handoff_day for daily strategy. The handoff_day attribute was only rendered for weekly strategy rotations, but the FireHydrant API also requires it for daily. The value was already correctly computed and stored in the database — it just wasn't being included in the Terraform output.

Bug 2: Incorrect EndDay for midnight-crossing daily restrictions. When a daily_restriction crosses midnight (e.g. 17:00 start + 10h duration = 03:00 next day), the EndDay was set to the same day as StartDay. FireHydrant interpreted this as spanning nearly a full week, causing overlap with restrictions for other days. The fix applies the same pattern already used in the OpsGenie handler — detect when the end time falls on a different day and advance EndDay accordingly.