### PR TITLE
Fix PagerDuty schedule import: rotation members format

### DIFF
--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -500,8 +500,10 @@ func TestPagerDuty(t *testing.T) {
 		t.Logf("Generated Terraform file:\n%s", tfContentStr)
 
 		// Extract the rotation resources for P3D7DLW-PSQ0VRL
-		// Look for the rotation resource that contains the expected member order
-		rotationRegex := regexp.MustCompile(`resource "firehydrant_rotation" "[^"]*" \{[\s\S]*?\}`)
+		// Look for the rotation resource that contains the expected member order.
+		// The regex matches from the resource declaration to a closing brace at the start of a line
+		// (top-level block boundary), which correctly spans nested blocks like members { ... }.
+		rotationRegex := regexp.MustCompile(`resource "firehydrant_rotation" "[^"]*" \{[\s\S]*?\n\}`)
 		rotationMatches := rotationRegex.FindAllString(tfContentStr, -1)
 
 		if len(rotationMatches) == 0 {
@@ -524,20 +526,12 @@ func TestPagerDuty(t *testing.T) {
 
 		t.Logf("Found target rotation:\n%s", targetRotation)
 
-		// Extract the members array from the Terraform resource
-		membersRegex := regexp.MustCompile(`members = \[([^\]]*)\]`)
-		membersMatch := membersRegex.FindStringSubmatch(targetRotation)
-
-		if len(membersMatch) < 2 {
-			t.Fatal("No members found in rotation resource")
-		}
-
-		membersStr := membersMatch[1]
-		t.Logf("Members string: %s", membersStr)
-
-		// Extract individual user references from the members array
+		// Extract user references from the nested members blocks:
+		//   members {
+		//     user_id = data.firehydrant_user.<slug>.id
+		//   }
 		userRefRegex := regexp.MustCompile(`data\.firehydrant_user\.([^\.]+)\.id`)
-		userRefMatches := userRefRegex.FindAllStringSubmatch(membersStr, -1)
+		userRefMatches := userRefRegex.FindAllStringSubmatch(targetRotation, -1)
 
 		if len(userRefMatches) != len(expectedOrder) {
 			t.Errorf("Expected %d user references in Terraform, got %d", len(expectedOrder), len(userRefMatches))

--- a/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy.golden.tf
+++ b/tfrender/testdata/TestRenderOpsgenie/EscalationPolicy.golden.tf
@@ -68,7 +68,18 @@ resource "firehydrant_rotation" "aj_team_aj_team_schedule_daytime_rotation" {
   schedule_id = firehydrant_on_call_schedule.aj_team_aj_team_schedule.id
   time_zone   = "America/Los_Angeles"
 
-  members = [data.firehydrant_user.fh_eng.id, data.firehydrant_user.fh_demo.id, data.firehydrant_user.fh_success.id, data.firehydrant_user.jsmith.id]
+  members {
+    user_id = data.firehydrant_user.fh_eng.id
+  }
+  members {
+    user_id = data.firehydrant_user.fh_demo.id
+  }
+  members {
+    user_id = data.firehydrant_user.fh_success.id
+  }
+  members {
+    user_id = data.firehydrant_user.jsmith.id
+  }
 
   strategy {
     type         = "weekly"
@@ -119,7 +130,18 @@ resource "firehydrant_rotation" "aj_team_aj_team_schedule_nighttime_rotation" {
   schedule_id = firehydrant_on_call_schedule.aj_team_aj_team_schedule.id
   time_zone   = "America/Los_Angeles"
 
-  members = [data.firehydrant_user.fh_eng.id, data.firehydrant_user.fh_demo.id, data.firehydrant_user.fh_success.id, data.firehydrant_user.jsmith.id]
+  members {
+    user_id = data.firehydrant_user.fh_eng.id
+  }
+  members {
+    user_id = data.firehydrant_user.fh_demo.id
+  }
+  members {
+    user_id = data.firehydrant_user.fh_success.id
+  }
+  members {
+    user_id = data.firehydrant_user.jsmith.id
+  }
 
   strategy {
     type         = "daily"

--- a/tfrender/testdata/TestRenderOpsgenie/TeamWithSchedules.golden.tf
+++ b/tfrender/testdata/TestRenderOpsgenie/TeamWithSchedules.golden.tf
@@ -163,7 +163,15 @@ resource "firehydrant_rotation" "aj_team_aj_team_schedule_nighttime_rotation" {
   schedule_id = firehydrant_on_call_schedule.aj_team_aj_team_schedule.id
   time_zone   = "America/Los_Angeles"
 
-  members = [data.firehydrant_user.mika.id, data.firehydrant_user.local.id, data.firehydrant_user.kiran.id]
+  members {
+    user_id = data.firehydrant_user.mika.id
+  }
+  members {
+    user_id = data.firehydrant_user.local.id
+  }
+  members {
+    user_id = data.firehydrant_user.kiran.id
+  }
 
   strategy {
     type         = "daily"

--- a/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
+++ b/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
@@ -148,7 +148,12 @@ resource "firehydrant_rotation" "aaaa_ipv6_migration_strategy_jen___primary_laye
   start_time  = "2024-04-10T20:39:29-07:00"
   # Note: Start time must be within 30 days.
 
-  members = [data.firehydrant_user.local.id, data.firehydrant_user.wong.id]
+  members {
+    user_id = data.firehydrant_user.local.id
+  }
+  members {
+    user_id = data.firehydrant_user.wong.id
+  }
 
   strategy {
     type           = "custom"

--- a/tfrender/tfrender.go
+++ b/tfrender/tfrender.go
@@ -415,30 +415,33 @@ func renderRotationData(ctx context.Context, rotation store.ExtRotation, r *TFRe
 		return fmt.Errorf("querying members for rotation '%s': %w", rotation.Name, err)
 	}
 
-	memberList := []hclwrite.Tokens{}
-	for _, m := range members {
-		member := hcl.Traversal{
-			hcl.TraverseRoot{Name: "data"},
-			hcl.TraverseAttr{Name: "firehydrant_user"},
-			hcl.TraverseAttr{Name: m.TFSlug()},
-			hcl.TraverseAttr{Name: "id"},
-		}
-		memberList = append(memberList, hclwrite.TokensForTraversal(member))
-	}
-
 	body.AppendNewline()
 
-	// This is dumb and I hate it
-	// We originally used members as part of the on_call_schedule resource, then the functionality changed and we needed to indicate
-	// that we were using the right implementation, so members became member_ids.  But then rotations didn't have this legacy, so used members
-	// from the beginning.  So now we need to support one for schedules and the other for rotations, but both take the same data.
-	membersName := ""
 	if useMembers {
-		membersName = "members"
+		// Rotation resources use nested "members" blocks with user_id attribute.
+		for _, m := range members {
+			body.AppendNewBlock("members", nil).Body().
+				SetAttributeTraversal("user_id", hcl.Traversal{
+					hcl.TraverseRoot{Name: "data"},
+					hcl.TraverseAttr{Name: "firehydrant_user"},
+					hcl.TraverseAttr{Name: m.TFSlug()},
+					hcl.TraverseAttr{Name: "id"},
+				})
+		}
 	} else {
-		membersName = "member_ids"
+		// Schedule resources use a flat "member_ids" list.
+		memberList := []hclwrite.Tokens{}
+		for _, m := range members {
+			member := hcl.Traversal{
+				hcl.TraverseRoot{Name: "data"},
+				hcl.TraverseAttr{Name: "firehydrant_user"},
+				hcl.TraverseAttr{Name: m.TFSlug()},
+				hcl.TraverseAttr{Name: "id"},
+			}
+			memberList = append(memberList, hclwrite.TokensForTraversal(member))
+		}
+		body.SetAttributeRaw("member_ids", hclwrite.TokensForTuple(memberList))
 	}
-	body.SetAttributeRaw(membersName, hclwrite.TokensForTuple(memberList))
 
 	// Add strategy
 	body.AppendNewline()


### PR DESCRIPTION
## BLUF

PagerDuty schedule imports had another bug causing incorrect or empty rotations in FireHydrant:

1. **Rotation `members` used wrong HCL format** — emitted as a flat list (`members = [...]`) instead of nested blocks (`members { user_id = ... }`), causing the TF provider to silently drop all members and create empty rotations.

## Changes

### Rotation members format (`tfrender/tfrender.go`)
- When rendering `firehydrant_rotation` resources (`useMembers=true`), emit `members` as nested blocks with `user_id` attribute using `AppendNewBlock`/`SetAttributeTraversal`
- Schedule resources (`useMembers=false`) continue using the flat `member_ids` list

### Tests
- Updated 4 golden files to match the new nested `members` block format
- Updated `TerraformOutputMatchesScheduleOrder` test regex to parse nested blocks instead of flat list