### PR TITLE
Fix PagerDuty migrator: skip ended layers, anchor rotations at virtual_start

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -372,11 +372,22 @@ func (p *PagerDuty) saveScheduleToDB(ctx context.Context, schedule pagerduty.Sch
 		return fmt.Errorf("saving schedule: %w", err)
 	}
 
-	// Create rotation records under the parent schedule (each layer becomes a rotation)
-	for i, layer := range schedule.ScheduleLayers {
-		if err := p.saveLayerToDB(ctx, schedule.ID, layer, i); err != nil {
+	// Create rotation records under the parent schedule (each layer becomes a rotation).
+	// PagerDuty keeps ended/replaced layers in the schedule_layers response with a non-null
+	// `end` timestamp. Skip those so they don't show up as extra FireHydrant rotations.
+	now := time.Now()
+	order := 0
+	for _, layer := range schedule.ScheduleLayers {
+		if layer.End != "" {
+			if end, err := time.Parse(time.RFC3339, layer.End); err == nil && end.Before(now) {
+				console.Warnf("Schedule layer %q (%s) ended at %s, skipping...\n", layer.Name, layer.ID, layer.End)
+				continue
+			}
+		}
+		if err := p.saveLayerToDB(ctx, schedule.ID, layer, order); err != nil {
 			return fmt.Errorf("saving layer to db: %w", err)
 		}
+		order++
 	}
 	return nil
 }

--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -413,7 +413,7 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 		Description:   desc,
 		Strategy:      "weekly",
 		ShiftDuration: "",
-		StartTime:     "",
+		StartTime:     layer.RotationVirtualStart,
 		HandoffTime:   "11:00:00",
 		HandoffDay:    "wednesday",
 		RotationOrder: int64(layerOrder),
@@ -427,15 +427,6 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	default:
 		rotationParams.Strategy = "custom"
 		rotationParams.ShiftDuration = fmt.Sprintf("PT%dS", layer.RotationTurnLengthSeconds)
-
-		now := time.Now()
-		loc, err := time.LoadLocation(schedule.Timezone)
-		if err == nil {
-			now = now.In(loc)
-		} else {
-			console.Warnf("unable to parse timezone '%v', using current machine's local time", schedule.Timezone)
-		}
-		rotationParams.StartTime = now.Format(time.RFC3339)
 	}
 	virtualStart, err := time.Parse(time.RFC3339, layer.RotationVirtualStart)
 	if err == nil {

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -320,6 +320,41 @@ func TestPagerDuty(t *testing.T) {
 		}
 	})
 
+	t.Run("LoadSchedulesSkipsEndedLayers", func(t *testing.T) {
+		t.Parallel()
+		ctx, pd := setup(t)
+
+		if err := pd.UseTeamInterface("team"); err != nil {
+			t.Fatalf("error setting team interface: %s", err)
+		}
+		if err := pd.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		if err := pd.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		if err := pd.LoadSchedules(ctx); err != nil {
+			t.Fatalf("error loading schedules: %s", err)
+		}
+
+		// Jack's schedule (P85QTXZ) has two layers in the fixture: PDEADPL with a past
+		// `end` timestamp and PE2BA4Y still active. Only the active one should become a rotation.
+		rotations, err := store.UseQueries(ctx).ListExtRotationsByScheduleID(ctx, "P85QTXZ")
+		if err != nil {
+			t.Fatalf("error loading rotations: %s", err)
+		}
+		if len(rotations) != 1 {
+			t.Fatalf("expected 1 rotation for P85QTXZ (ended layer should be filtered), got %d", len(rotations))
+		}
+		if rotations[0].ID != "PE2BA4Y" {
+			t.Errorf("expected active rotation PE2BA4Y, got %s", rotations[0].ID)
+		}
+
+		if _, err := store.UseQueries(ctx).GetExtRotation(ctx, "PDEADPL"); err == nil {
+			t.Error("ended layer PDEADPL should not be imported as a rotation")
+		}
+	})
+
 	t.Run("LoadSchedulesSkipsScheduleWithMissingTeam", func(t *testing.T) {
 		t.Parallel()
 		ctx, pd := setup(t)

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -355,6 +355,35 @@ func TestPagerDuty(t *testing.T) {
 		}
 	})
 
+	t.Run("LoadSchedulesPreservesVirtualStart", func(t *testing.T) {
+		t.Parallel()
+		ctx, pd := setup(t)
+
+		if err := pd.UseTeamInterface("team"); err != nil {
+			t.Fatalf("error setting team interface: %s", err)
+		}
+		if err := pd.LoadUsers(ctx); err != nil {
+			t.Fatalf("error loading users: %s", err)
+		}
+		if err := pd.LoadTeams(ctx); err != nil {
+			t.Fatalf("error loading teams: %s", err)
+		}
+		if err := pd.LoadSchedules(ctx); err != nil {
+			t.Fatalf("error loading schedules: %s", err)
+		}
+
+		// Jack's active layer PE2BA4Y has rotation_virtual_start 2023-06-02T14:00:00-07:00 in
+		// the fixture. The migrator must persist this as StartTime so the rendered TF anchors
+		// the rotation at PagerDuty's virtual start instead of drifting with apply time.
+		r, err := store.UseQueries(ctx).GetExtRotation(ctx, "PE2BA4Y")
+		if err != nil {
+			t.Fatalf("error loading rotation PE2BA4Y: %s", err)
+		}
+		if r.StartTime != "2023-06-02T14:00:00-07:00" {
+			t.Errorf("expected StartTime from rotation_virtual_start, got %q", r.StartTime)
+		}
+	})
+
 	t.Run("LoadSchedulesSkipsScheduleWithMissingTeam", func(t *testing.T) {
 		t.Parallel()
 		ctx, pd := setup(t)

--- a/pager/testdata/TestPagerDuty/apiserver/schedules-include-5b-5d-schedule_layers.json
+++ b/pager/testdata/TestPagerDuty/apiserver/schedules-include-5b-5d-schedule_layers.json
@@ -201,6 +201,28 @@
       "name": "Jack On-Call Schedule",
       "schedule_layers": [
         {
+          "end": "2020-01-01T00:00:00Z",
+          "id": "PDEADPL",
+          "name": "Jack retired layer",
+          "rendered_coverage_percentage": null,
+          "rendered_schedule_entries": [],
+          "restrictions": [],
+          "rotation_turn_length_seconds": 604800,
+          "rotation_virtual_start": "2019-01-01T00:00:00Z",
+          "start": "2019-01-01T00:00:00Z",
+          "users": [
+            {
+              "user": {
+                "html_url": "https://acme-inc.pagerduty.com/users/P4CMCAU",
+                "id": "P4CMCAU",
+                "self": "https://api.pagerduty.com/users/P4CMCAU",
+                "summary": "Jack T.",
+                "type": "user_reference"
+              }
+            }
+          ]
+        },
+        {
           "end": null,
           "id": "PE2BA4Y",
           "name": "Layer 1",

--- a/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
+++ b/tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf
@@ -86,7 +86,7 @@ resource "firehydrant_on_call_schedule" "aaaa_ipv6_migration_strategy_jen_primar
   team_id     = firehydrant_team.aaaa_ipv6_migration_strategy.id
   time_zone   = "America/Los_Angeles"
   start_time  = "2024-04-10T20:39:29-07:00"
-  # Note: Start time must be within 30 days.
+  # Note: Start time must be within 1 month of apply.
 
   member_ids = [data.firehydrant_user.kiran.id]
 
@@ -146,7 +146,7 @@ resource "firehydrant_rotation" "aaaa_ipv6_migration_strategy_jen_primary_layer_
   schedule_id = firehydrant_on_call_schedule.aaaa_ipv6_migration_strategy_jen_primary.id
   time_zone   = "America/Los_Angeles"
   start_time  = "2024-04-10T20:39:29-07:00"
-  # Note: Start time must be within 30 days.
+  # Note: Start time must be within 1 month of apply.
 
   members {
     user_id = data.firehydrant_user.local.id

--- a/tfrender/tfrender.go
+++ b/tfrender/tfrender.go
@@ -401,10 +401,13 @@ func renderRotationData(ctx context.Context, rotation store.ExtRotation, r *TFRe
 
 	body.SetAttributeValue("time_zone", cty.StringVal(schedule.Timezone))
 
-	// Add start_time if rotation has custom strategy
-	if rotation.Strategy == "custom" && rotation.StartTime != "" {
+	// Anchor the rotation at the source system's virtual start so assignments
+	// match regardless of when terraform apply runs. FireHydrant rejects a
+	// start_time more than 1 month in the past; callers need to refresh the
+	// source data if the virtual start is older than that window.
+	if rotation.StartTime != "" {
 		body.SetAttributeValue("start_time", cty.StringVal(rotation.StartTime))
-		r.AppendComment(body, "Note: Start time must be within 30 days.")
+		r.AppendComment(body, "Note: Start time must be within 1 month of apply.")
 	}
 
 	// Add members

--- a/tfrender/tfrender_test.go
+++ b/tfrender/tfrender_test.go
@@ -191,7 +191,7 @@ func TestRenderOnCallScheduleResource(t *testing.T) {
 		ScheduleID:    "id-for-ext-schedule-0",
 		Name:          "Daily Rotation",
 		Strategy:      "daily",
-		StartTime:     "11:00",
+		StartTime:     "",
 		HandoffTime:   "11:00",
 		HandoffDay:    "wednesday",
 		RotationOrder: 0,


### PR DESCRIPTION
## BLUF

Two migrator fixes for PagerDuty imports: historical (ended) schedule layers are no longer imported as extra FireHydrant rotations, and daily/weekly rotations now anchor at PagerDuty's `rotation_virtual_start` so member assignments match PagerDuty regardless of when `terraform apply` runs.

## Description

Two related bugs surfaced.

### 1. Extra rotations from ended schedule layers (`047f11c`)

PagerDuty's `GET /schedules?include[]=schedule_layers` returns **every** layer a schedule has ever had — historical ones just get a non-null `end` timestamp. The importer iterated `schedule.ScheduleLayers` without filtering, so layers that ended months or years ago still became `firehydrant_rotation` resources. In Sandy's case, three layers ended on 2025-10-20 (`Wednesday-NAM-schedule`, `Thursday-NAM-schedule`, `Friday-NAM-schedule`) and were emitted as rotations on the `2025-PA-consolidated-weekend-schedule` even though they haven't paged anyone in six months.

**Fix:** at `pager/pagerduty.go:376`, skip any layer whose `end` parses to a timestamp before `time.Now()`. We use `console.Warnf` on skip (matches existing "skipping…" messages in the file) and keep the rotation order contiguous with a manual counter.

**Alternatives considered:**
- *Skip any layer with `end != ""` regardless of value.* Rejected: a future-dated `end` means the layer is currently active and will stop in the future — those should still import.
- *Do nothing, document it.* Rejected: the bug causes incorrect on-call in FH, not just noise.

**Risks:** small. The filter is off-by-default (`end == ""` or parse failure or `end >= now`); malformed data still imports. Our existing test fixtures have `"end": null` so no golden data had to move; added a new fixture (`PDEADPL`) and subtest `LoadSchedulesSkipsEndedLayers` to guard the regression.

### 2. Wrong assignees from missing rotation anchor (`a80966f`)

For `custom` strategies, the importer was writing `start_time` on the rendered `firehydrant_rotation`. For `daily` and `weekly` it wasn't. In that case, FireHydrant's scheduler (`laddertruck/packs/signals/app/lib/signals/base_scheduler.rb:127-129`) falls back to `Time.current.beginning_of_week(handoff_day)`, so the rotation anchors at whatever week `terraform apply` ran in — not at PagerDuty's `rotation_virtual_start`. Every handoff between those two anchors shifts the assignments by one member, which is why Sandy saw "different people on different weeks but not every week" — the drift depended on when she applied.

**Fix:** `pager/pagerduty.go` always stores `layer.RotationVirtualStart` in `ext_rotations.start_time`. `tfrender/tfrender.go` emits a top-level `start_time = "…"` on the rotation resource whenever it's set, regardless of strategy. The terraform-provider-firehydrant rotation resource already accepted this top-level attribute (`provider/rotation_resource.go:139-143, 355-359`).

**Alternatives considered:**
- *Emit `effective_at` instead of `start_time`.* Rejected: `effective_at` is update-semantics only ("apply the new config at time T"); `start_time` is the rotation-creation anchor. Different endpoints, different semantics.
- *Compute `handoff_day`/`handoff_time` so the default anchor happens to line up.* Rejected: impossible because FH's default uses `Time.current`, which we can't influence from TF.

**Trade-offs / known caveat:** `on_call_rotation_creator.rb:35` rejects a `start_time` more than 1 month in the past. For Sandy's current data every `virtual_start` is inside that window, so the straightforward fix applies cleanly. For long-lived rotations whose `virtual_start` is older than a month, the migrator will need to roll it forward by whole rotation cycles — that's a follow-up, not in this PR.

### How the hypothesis was validated

Before writing the fix we verified against a local laddertruck using `POST /v1/teams/{team}/on_call_schedules/preview` (wraps shift generation in a rolled-back transaction). Same rotation payload with and without `start_time` on a weekly weekend rotation (`rotation_virtual_start = 2026-03-31T12:00`, cycle = 7 members × 7 days):

| Weekend     | WITHOUT `start_time`  | WITH `start_time = 2026-03-31T12:00:00-07:00` | PD truth |
|-------------|-----------------------|-----------------------------------------------|----------|
| 2026-04-17  | m[0] Acme Eng         | **m[2] Amanda Ziemann**                       | m[2] ✓   |
| 2026-04-24  | m[1] Admin Account    | **m[3] Blake Yost**                           | m[3] ✓   |
| 2026-05-01  | m[2] Amanda Ziemann   | **m[4] Bradly Koelpin**                       | m[4] ✓   |

Drift without `start_time` = `(apply-week anchor − virtual-start anchor) / turn_length` = `14d / 7d = 2` handoffs. Matches the predicted offset exactly.

## Testing Notes

- Added `LoadSchedulesSkipsEndedLayers` subtest — asserts an ended layer does not become a rotation, and the one active layer on the same schedule still does.
- Added `LoadSchedulesPreservesVirtualStart` subtest — asserts `ext_rotations.start_time` equals `rotation_virtual_start` after import.
- Regenerated `tfrender/testdata/TestRenderPagerDuty/TeamWithSchedules.golden.tf` for the comment-text change ("30 days" → "1 month of apply").
- Fixed seed data in `TestRenderOnCallScheduleResource` that stored `"11:00"` in `StartTime` (never a valid RFC3339 value; now empty).
- Full suite: `go test ./...` green.
- Regression guard verified: each new subtest fails when the corresponding fix is reverted via `git stash`.

## Additional Notes for Reviewers

- Focus areas: `pager/pagerduty.go` (two logical changes — end-date filter + start_time preservation), and `tfrender/tfrender.go` (strategy-agnostic `start_time` emission).
- The Opsgenie and VictorOps importers weren't touched; worth a follow-up audit to see whether they expose analogous historical-layer or virtual-start semantics.
- Follow-up ticket to create: roll `virtual_start` forward by whole rotation cycles when it falls outside FH's 1-month acceptance window.