### PR TITLE
Roll PagerDuty virtual_start forward to fit FireHydrant's 1-month window

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -419,6 +419,7 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 		RotationOrder: int64(layerOrder),
 	}
 
+	turn := time.Duration(layer.RotationTurnLengthSeconds) * time.Second
 	switch layer.RotationTurnLengthSeconds {
 	case 60 * 60 * 24:
 		rotationParams.Strategy = "daily"
@@ -432,6 +433,12 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	if err == nil {
 		rotationParams.HandoffTime = virtualStart.Format(time.TimeOnly)
 		rotationParams.HandoffDay = strings.ToLower(virtualStart.Weekday().String())
+		// FireHydrant rejects rotation start_time older than 1 month. Roll
+		// virtual_start forward in whole rotation cycles so the anchor lands
+		// inside that window while preserving rotation phase — whoever PD has
+		// on call now will still be on call after rollforward.
+		rolled := rollVirtualStartForward(virtualStart, turn, time.Now())
+		rotationParams.StartTime = rolled.Format(time.RFC3339)
 	} else {
 		console.Errorf("unable to parse virtual start time '%v', assuming default values", layer.RotationVirtualStart)
 	}
@@ -517,6 +524,29 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	}
 
 	return nil
+}
+
+// fhStartTimeWindow is the safety margin we keep under FireHydrant's 1-month
+// start_time acceptance window. Rolling the virtual_start to within this many
+// days of `now` leaves room for the gap between TF generation and apply.
+const fhStartTimeWindow = 25 * 24 * time.Hour
+
+// rollVirtualStartForward advances virtualStart by whole turn-length cycles
+// until it sits within FireHydrant's start_time acceptance window. Because the
+// step is the rotation's own period, the rotation phase (which user is on call
+// now) is preserved. Returns virtualStart unchanged when turn is non-positive
+// or when virtualStart is already inside the window.
+func rollVirtualStartForward(virtualStart time.Time, turn time.Duration, now time.Time) time.Time {
+	if turn <= 0 {
+		return virtualStart
+	}
+	cutoff := now.Add(-fhStartTimeWindow)
+	if !virtualStart.Before(cutoff) {
+		return virtualStart
+	}
+	gap := cutoff.Sub(virtualStart)
+	steps := int64(gap/turn) + 1
+	return virtualStart.Add(time.Duration(steps) * turn)
 }
 
 func (p *PagerDuty) LoadEscalationPolicies(ctx context.Context) error {

--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -526,9 +526,11 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	return nil
 }
 
-// fhStartTimeWindow is the safety margin we keep under FireHydrant's 1-month
-// start_time acceptance window. Rolling the virtual_start to within this many
-// days of `now` leaves room for the gap between TF generation and apply.
+// fhStartTimeWindow is the maximum age we'll allow a rolled virtual_start to
+// have. FireHydrant rejects rotation start_time older than 30 days; we
+// deliberately stop 5 days short of that limit so a TF generated today still
+// applies cleanly if the customer waits a few days before running
+// `terraform apply`.
 const fhStartTimeWindow = 25 * 24 * time.Hour
 
 // rollVirtualStartForward advances virtualStart by whole turn-length cycles

--- a/pager/pagerduty_internal_test.go
+++ b/pager/pagerduty_internal_test.go
@@ -1,0 +1,78 @@
+package pager
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRollVirtualStartForward(t *testing.T) {
+	mustParse := func(s string) time.Time {
+		t.Helper()
+		v, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("parsing %q: %s", s, err)
+		}
+		return v
+	}
+
+	now := mustParse("2026-05-08T12:00:00-07:00")
+	day := 24 * time.Hour
+	week := 7 * day
+
+	tests := []struct {
+		name         string
+		virtualStart string
+		turn         time.Duration
+		want         string
+	}{
+		{
+			name:         "already within window leaves untouched",
+			virtualStart: "2026-04-28T09:30:00-07:00",
+			turn:         day,
+			want:         "2026-04-28T09:30:00-07:00",
+		},
+		{
+			name:         "weekly rotation rolls forward to within window preserving weekday",
+			virtualStart: "2023-06-02T14:00:00-07:00", // Friday
+			turn:         week,
+			want:         "2026-04-17T14:00:00-07:00", // first Friday at-or-after cutoff
+		},
+		{
+			name:         "daily rotation rolls forward by days",
+			virtualStart: "2025-02-10T03:00:00-08:00",
+			turn:         day,
+			want:         "2026-04-14T03:00:00-08:00", // first daily anchor at-or-after cutoff
+		},
+		{
+			name:         "future virtual_start untouched",
+			virtualStart: "2026-06-01T00:00:00-07:00",
+			turn:         day,
+			want:         "2026-06-01T00:00:00-07:00",
+		},
+		{
+			name:         "zero turn returns input unchanged",
+			virtualStart: "2020-01-01T00:00:00Z",
+			turn:         0,
+			want:         "2020-01-01T00:00:00Z",
+		},
+		{
+			name:         "monthly turn jumps past the cutoff in a single step",
+			virtualStart: "2025-02-10T03:00:00-08:00",
+			turn:         30 * day,
+			want:         "2026-05-06T03:00:00-08:00",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rollVirtualStartForward(mustParse(tc.virtualStart), tc.turn, now)
+			if !got.Equal(mustParse(tc.want)) {
+				t.Fatalf("got %s, want %s", got.Format(time.RFC3339), tc.want)
+			}
+			cutoff := now.Add(-fhStartTimeWindow)
+			if tc.turn > 0 && got.Before(cutoff) && !got.Equal(mustParse(tc.virtualStart)) {
+				t.Fatalf("rolled value %s is still before cutoff %s", got, cutoff)
+			}
+		})
+	}
+}

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/firehydrant/signals-migrator/pager"
 	"github.com/firehydrant/signals-migrator/store"
@@ -355,7 +356,7 @@ func TestPagerDuty(t *testing.T) {
 		}
 	})
 
-	t.Run("LoadSchedulesPreservesVirtualStart", func(t *testing.T) {
+	t.Run("LoadSchedulesRollsVirtualStartIntoFireHydrantWindow", func(t *testing.T) {
 		t.Parallel()
 		ctx, pd := setup(t)
 
@@ -372,15 +373,39 @@ func TestPagerDuty(t *testing.T) {
 			t.Fatalf("error loading schedules: %s", err)
 		}
 
-		// Jack's active layer PE2BA4Y has rotation_virtual_start 2023-06-02T14:00:00-07:00 in
-		// the fixture. The migrator must persist this as StartTime so the rendered TF anchors
-		// the rotation at PagerDuty's virtual start instead of drifting with apply time.
+		// Jack's active layer PE2BA4Y has rotation_virtual_start 2023-06-02T14:00:00-07:00
+		// (a Friday) and a 1-week turn. FireHydrant rejects start_time older than 1 month,
+		// so the migrator rolls the anchor forward in whole 7-day cycles. The rolled value
+		// must (a) sit within ~1 month of now, (b) preserve weekday + time-of-day, and
+		// (c) differ from the original by an integer number of weeks.
 		r, err := store.UseQueries(ctx).GetExtRotation(ctx, "PE2BA4Y")
 		if err != nil {
 			t.Fatalf("error loading rotation PE2BA4Y: %s", err)
 		}
-		if r.StartTime != "2023-06-02T14:00:00-07:00" {
-			t.Errorf("expected StartTime from rotation_virtual_start, got %q", r.StartTime)
+
+		original, err := time.Parse(time.RFC3339, "2023-06-02T14:00:00-07:00")
+		if err != nil {
+			t.Fatalf("parsing original virtual_start: %s", err)
+		}
+		got, err := time.Parse(time.RFC3339, r.StartTime)
+		if err != nil {
+			t.Fatalf("parsing rolled StartTime %q: %s", r.StartTime, err)
+		}
+
+		if got.Weekday() != original.Weekday() {
+			t.Errorf("weekday changed: original=%s rolled=%s", original.Weekday(), got.Weekday())
+		}
+		if got.Hour() != original.Hour() || got.Minute() != original.Minute() || got.Second() != original.Second() {
+			t.Errorf("time-of-day changed: original=%s rolled=%s",
+				original.Format(time.TimeOnly), got.Format(time.TimeOnly))
+		}
+		delta := got.Sub(original)
+		week := 7 * 24 * time.Hour
+		if delta < 0 || delta%week != 0 {
+			t.Errorf("rolled value is not a non-negative multiple of one week from original: delta=%s", delta)
+		}
+		if cutoff := time.Now().Add(-26 * 24 * time.Hour); got.Before(cutoff) {
+			t.Errorf("rolled StartTime %s is older than 26 days, FireHydrant will reject it", r.StartTime)
 		}
 	})
 


### PR DESCRIPTION
## BLUF

The PagerDuty importer now rolls each layer's `rotation_virtual_start` forward by whole rotation cycles into FireHydrant's 1-month `start_time` acceptance window. Customers whose PD layers had `virtual_start` values older than 1 month no longer silently lose those rotations on `terraform apply`.

## Description

PagerDuty's `rotation_virtual_start` can be arbitrarily old (years, in real customer data). PR #219 began emitting it as the FireHydrant rotation `start_time` so the rotation phase would be preserved across applies. But FireHydrant's API rejects any `start_time` older than 1 month (`on_call_rotation_creator.rb`), so for stale anchors `terraform apply` would error on those individual `firehydrant_rotation` resources while the rest of the apply continued. The visible symptom: schedules with multiple PD layers appeared in FireHydrant with only the layer that was inlined into `firehydrant_on_call_schedule`; every additional `firehydrant_rotation` whose anchor was stale was missing entirely. Across one customer TF this dropped 13/14 rotations on one schedule, 3/4 on another, etc.

Fix: in `saveLayerToDB`, after parsing `rotation_virtual_start`, advance it by whole `rotation_turn_length_seconds` increments until it lands within a 25-day cutoff (margin under FH's 30-day limit). Because the step equals the rotation's own period, the rotation phase is preserved — whoever PagerDuty has on call right now is still on call right now after rollforward, just anchored at a recent equivalent moment. The logic is extracted into a small unexported helper `rollVirtualStartForward(virtualStart, turn, now)` so it's testable in isolation.

**Alternatives considered:**
1. *Drop `start_time` when stale and fall back to FH's default anchor.* Rejected — that's exactly the drift bug PR #219 fixed; we'd reintroduce it for these customers.
2. *Cap `start_time` to `now - 25d` regardless of phase.* Rejected — the resulting rotation phase wouldn't match PD, so on-call assignments would be wrong from day one.
3. *Move the rollforward into the FH provider or API.* Rejected — the migrator owns the PD-to-FH translation layer, and the FH API's 1-month rule is a stable boundary worth respecting at the source.

**Risks / trade-offs:**
- The cutoff is wall-clock based (`time.Now()`), so a TF generated and applied across a 25-day gap could still drift past FH's 30-day limit. The 5-day margin is intentional; if customers routinely take longer than that, we can tighten the cutoff.
- For rotations whose `rotation_turn_length` is itself longer than 25 days (uncommon but possible with `custom` strategies), the rolled anchor may land in the future. FireHydrant accepts future `start_time`, so this is fine, but worth noting.
- No backfill for already-applied state. Customers with the silent-drop symptom will need to regenerate their TF and re-apply to pick up the missing rotations.

**Context for future readers:**
- PR #219 is the prerequisite that introduced `start_time` emission.
- `pagerduty.go:saveLayerToDB` is the single funnel for all PD layer → FH rotation translation; this is the right (and only) place for the rollforward.