### PR TITLE
Fix on-call cursor drift when PD virtual_start lies in the past

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -429,15 +429,19 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 		rotationParams.Strategy = "custom"
 		rotationParams.ShiftDuration = fmt.Sprintf("PT%dS", layer.RotationTurnLengthSeconds)
 	}
+	cursorOffset := 0
 	virtualStart, err := time.Parse(time.RFC3339, layer.RotationVirtualStart)
 	if err == nil {
 		rotationParams.HandoffTime = virtualStart.Format(time.TimeOnly)
 		rotationParams.HandoffDay = strings.ToLower(virtualStart.Weekday().String())
-		// FireHydrant rejects rotation start_time older than 1 month. Roll
-		// virtual_start forward in whole rotation cycles so the anchor lands
-		// inside that window while preserving rotation phase — whoever PD has
-		// on call now will still be on call after rollforward.
-		rolled := rollVirtualStartForward(virtualStart, turn, time.Now())
+		// FireHydrant's empty-window scheduler advances time without rotating
+		// the cursor when a cycle has no generatable shifts (e.g. when
+		// virtual_start lies in the past). Roll virtual_start forward to the
+		// most recent cycle boundary at-or-before now, and capture the number
+		// of cycles advanced — we use it below to rotate the member list so
+		// PagerDuty's currently-on-call user lands at index 0 in FireHydrant.
+		var rolled time.Time
+		rolled, cursorOffset = rollVirtualStartForward(virtualStart, turn, time.Now())
 		rotationParams.StartTime = rolled.Format(time.RFC3339)
 	} else {
 		console.Errorf("unable to parse virtual start time '%v', assuming default values", layer.RotationVirtualStart)
@@ -451,9 +455,12 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	// ExtRotationMembers
 	// Add only the users specifically assigned to this schedule layer.
 	// Team members who aren't in the layer will still be on the team but won't be in this rotation.
-	for i, user := range layer.Users {
-		// Store the order of members as they appear in the API response
-		// This preserves the exact order from PagerDuty
+	users := layer.Users
+	if n := len(users); n > 0 && cursorOffset > 0 {
+		cursor := cursorOffset % n
+		users = append(append([]pagerduty.UserReference{}, layer.Users[cursor:]...), layer.Users[:cursor]...)
+	}
+	for i, user := range users {
 		if err := q.InsertExtRotationMember(ctx, store.InsertExtRotationMemberParams{
 			RotationID:  layer.ID,
 			UserID:      user.User.ID,
@@ -526,29 +533,26 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	return nil
 }
 
-// fhStartTimeWindow is the maximum age we'll allow a rolled virtual_start to
-// have. FireHydrant rejects rotation start_time older than 30 days; we
-// deliberately stop 5 days short of that limit so a TF generated today still
-// applies cleanly if the customer waits a few days before running
-// `terraform apply`.
-const fhStartTimeWindow = 25 * 24 * time.Hour
-
 // rollVirtualStartForward advances virtualStart by whole turn-length cycles
-// until it sits within FireHydrant's start_time acceptance window. Because the
-// step is the rotation's own period, the rotation phase (which user is on call
-// now) is preserved. Returns virtualStart unchanged when turn is non-positive
-// or when virtualStart is already inside the window.
-func rollVirtualStartForward(virtualStart time.Time, turn time.Duration, now time.Time) time.Time {
-	if turn <= 0 {
-		return virtualStart
+// to land on the most recent cycle boundary at-or-before now, and returns the
+// number of cycles advanced. Callers must reorder the layer's member list by
+// that offset so PagerDuty's currently-on-call user lands at index 0 in
+// FireHydrant — otherwise FireHydrant's empty-window scheduler will leave the
+// cursor on the original index 0 and the rotation will drift by `offset`
+// positions relative to PagerDuty.
+//
+// Returns (virtualStart, 0) when turn is non-positive or virtualStart is not
+// before now (the rotation either has no defined cycle or hasn't started yet).
+func rollVirtualStartForward(virtualStart time.Time, turn time.Duration, now time.Time) (time.Time, int) {
+	if turn <= 0 || !virtualStart.Before(now) {
+		return virtualStart, 0
 	}
-	cutoff := now.Add(-fhStartTimeWindow)
-	if !virtualStart.Before(cutoff) {
-		return virtualStart
+	elapsed := now.Sub(virtualStart)
+	cycles := int(elapsed / turn)
+	if cycles == 0 {
+		return virtualStart, 0
 	}
-	gap := cutoff.Sub(virtualStart)
-	steps := int64(gap/turn) + 1
-	return virtualStart.Add(time.Duration(steps) * turn)
+	return virtualStart.Add(time.Duration(cycles) * turn), cycles
 }
 
 func (p *PagerDuty) LoadEscalationPolicies(ctx context.Context) error {

--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -455,11 +455,7 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	// ExtRotationMembers
 	// Add only the users specifically assigned to this schedule layer.
 	// Team members who aren't in the layer will still be on the team but won't be in this rotation.
-	users := layer.Users
-	if n := len(users); n > 0 && cursorOffset > 0 {
-		cursor := cursorOffset % n
-		users = append(append([]pagerduty.UserReference{}, layer.Users[cursor:]...), layer.Users[:cursor]...)
-	}
+	users := rotateUsersForward(layer.Users, cursorOffset)
 	for i, user := range users {
 		if err := q.InsertExtRotationMember(ctx, store.InsertExtRotationMemberParams{
 			RotationID:  layer.ID,
@@ -531,6 +527,30 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 	}
 
 	return nil
+}
+
+// rotateUsersForward returns users reordered so that users[cursor mod len(users)]
+// becomes the first element. Used to compensate for FireHydrant's empty-window
+// scheduler: rolling virtual_start forward by N cycles shifts FH's effective
+// cursor by N positions, so we pre-rotate the member list by the same amount
+// to keep PagerDuty's currently-on-call user at FireHydrant's index 0.
+//
+// Returns users unchanged when cursor is non-positive, when the list has fewer
+// than two elements, or when cursor mod len(users) is 0. Otherwise allocates a
+// fresh slice — never mutates the input.
+func rotateUsersForward(users []pagerduty.UserReference, cursor int) []pagerduty.UserReference {
+	n := len(users)
+	if cursor <= 0 || n < 2 {
+		return users
+	}
+	c := cursor % n
+	if c == 0 {
+		return users
+	}
+	rotated := make([]pagerduty.UserReference, n)
+	copy(rotated, users[c:])
+	copy(rotated[n-c:], users[:c])
+	return rotated
 }
 
 // rollVirtualStartForward advances virtualStart by whole turn-length cycles

--- a/pager/pagerduty_internal_test.go
+++ b/pager/pagerduty_internal_test.go
@@ -172,10 +172,6 @@ func TestRotateUsersForward(t *testing.T) {
 			want:   []string{"b", "a"},
 		},
 		{
-			// Mirrors the production scenario this PR exists to fix: a PagerDuty
-			// weekly layer with seven users whose virtual_start is one full
-			// cycle in the past. The cursor offset of 1 must put the
-			// second-in-PD-order user at index 0 in the emitted FH rotation.
 			name:   "weekly layer with seven users and cursor of one puts second-in-PD user first",
 			input:  []string{"user_a", "user_b", "user_c", "user_d", "user_e", "user_f", "user_g"},
 			cursor: 1,

--- a/pager/pagerduty_internal_test.go
+++ b/pager/pagerduty_internal_test.go
@@ -1,8 +1,11 @@
 package pager
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
 )
 
 func TestRollVirtualStartForward(t *testing.T) {
@@ -85,6 +88,118 @@ func TestRollVirtualStartForward(t *testing.T) {
 			}
 			if gotOffset != tc.wantOffset {
 				t.Errorf("offset: got %d, want %d", gotOffset, tc.wantOffset)
+			}
+		})
+	}
+}
+
+func TestRotateUsersForward(t *testing.T) {
+	user := func(id string) pagerduty.UserReference {
+		return pagerduty.UserReference{User: pagerduty.APIObject{ID: id}}
+	}
+	ids := func(users []pagerduty.UserReference) []string {
+		out := make([]string, len(users))
+		for i, u := range users {
+			out[i] = u.User.ID
+		}
+		return out
+	}
+
+	tests := []struct {
+		name   string
+		input  []string
+		cursor int
+		want   []string
+	}{
+		{
+			name:   "cursor zero leaves order unchanged",
+			input:  []string{"a", "b", "c"},
+			cursor: 0,
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "negative cursor leaves order unchanged",
+			input:  []string{"a", "b", "c"},
+			cursor: -1,
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "cursor one shifts head by one",
+			input:  []string{"a", "b", "c"},
+			cursor: 1,
+			want:   []string{"b", "c", "a"},
+		},
+		{
+			name:   "cursor two shifts head by two",
+			input:  []string{"a", "b", "c"},
+			cursor: 2,
+			want:   []string{"c", "a", "b"},
+		},
+		{
+			name:   "cursor equal to length wraps to no-op",
+			input:  []string{"a", "b", "c"},
+			cursor: 3,
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "cursor greater than length wraps",
+			input:  []string{"a", "b", "c"},
+			cursor: 4,
+			want:   []string{"b", "c", "a"},
+		},
+		{
+			name:   "cursor much greater than length wraps via modulo",
+			input:  []string{"a", "b", "c", "d", "e", "f", "g"},
+			cursor: 152, // matches the multi-year case in TestRollVirtualStartForward
+			want:   []string{"f", "g", "a", "b", "c", "d", "e"},
+		},
+		{
+			name:   "single user stays in place regardless of cursor",
+			input:  []string{"only"},
+			cursor: 99,
+			want:   []string{"only"},
+		},
+		{
+			name:   "empty input stays empty",
+			input:  []string{},
+			cursor: 5,
+			want:   []string{},
+		},
+		{
+			name:   "two users alternate",
+			input:  []string{"a", "b"},
+			cursor: 1,
+			want:   []string{"b", "a"},
+		},
+		{
+			// Mirrors the production scenario this PR exists to fix: a PagerDuty
+			// weekly layer with seven users whose virtual_start is one full
+			// cycle in the past. The cursor offset of 1 must put the
+			// second-in-PD-order user at index 0 in the emitted FH rotation.
+			name:   "weekly layer with seven users and cursor of one puts second-in-PD user first",
+			input:  []string{"user_a", "user_b", "user_c", "user_d", "user_e", "user_f", "user_g"},
+			cursor: 1,
+			want:   []string{"user_b", "user_c", "user_d", "user_e", "user_f", "user_g", "user_a"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := make([]pagerduty.UserReference, len(tc.input))
+			for i, id := range tc.input {
+				input[i] = user(id)
+			}
+
+			// Snapshot the input so we can prove the helper never mutates it.
+			inputSnapshot := append([]pagerduty.UserReference{}, input...)
+
+			got := rotateUsersForward(input, tc.cursor)
+
+			if !reflect.DeepEqual(ids(got), tc.want) {
+				t.Errorf("rotated order: got %v, want %v", ids(got), tc.want)
+			}
+			if !reflect.DeepEqual(input, inputSnapshot) {
+				t.Errorf("input was mutated: got %v, want %v", ids(input), ids(inputSnapshot))
 			}
 		})
 	}

--- a/pager/pagerduty_internal_test.go
+++ b/pager/pagerduty_internal_test.go
@@ -23,55 +23,68 @@ func TestRollVirtualStartForward(t *testing.T) {
 		name         string
 		virtualStart string
 		turn         time.Duration
-		want         string
+		wantStart    string
+		wantOffset   int
 	}{
 		{
-			name:         "already within window leaves untouched",
-			virtualStart: "2026-04-28T09:30:00-07:00",
+			name:         "less than one turn elapsed leaves anchor and cursor untouched",
+			virtualStart: "2026-05-08T09:30:00-07:00",
 			turn:         day,
-			want:         "2026-04-28T09:30:00-07:00",
+			wantStart:    "2026-05-08T09:30:00-07:00",
+			wantOffset:   0,
 		},
 		{
-			name:         "weekly rotation rolls forward to within window preserving weekday",
+			name:         "weekly rotation rolls one cycle forward when virtual_start is 10 days old",
+			virtualStart: "2026-04-28T09:30:00-07:00",
+			turn:         week,
+			wantStart:    "2026-05-05T09:30:00-07:00",
+			wantOffset:   1,
+		},
+		{
+			name:         "weekly rotation rolls multiple years forward preserving weekday",
 			virtualStart: "2023-06-02T14:00:00-07:00", // Friday
 			turn:         week,
-			want:         "2026-04-17T14:00:00-07:00", // first Friday at-or-after cutoff
+			wantStart:    "2026-05-01T14:00:00-07:00", // most recent Friday cycle boundary at-or-before now
+			wantOffset:   152,
 		},
 		{
-			name:         "daily rotation rolls forward by days",
+			name:         "daily rotation rolls to most recent daily anchor",
 			virtualStart: "2025-02-10T03:00:00-08:00",
 			turn:         day,
-			want:         "2026-04-14T03:00:00-08:00", // first daily anchor at-or-after cutoff
+			wantStart:    "2026-05-08T03:00:00-08:00",
+			wantOffset:   452,
 		},
 		{
 			name:         "future virtual_start untouched",
 			virtualStart: "2026-06-01T00:00:00-07:00",
 			turn:         day,
-			want:         "2026-06-01T00:00:00-07:00",
+			wantStart:    "2026-06-01T00:00:00-07:00",
+			wantOffset:   0,
 		},
 		{
 			name:         "zero turn returns input unchanged",
 			virtualStart: "2020-01-01T00:00:00Z",
 			turn:         0,
-			want:         "2020-01-01T00:00:00Z",
+			wantStart:    "2020-01-01T00:00:00Z",
+			wantOffset:   0,
 		},
 		{
-			name:         "monthly turn jumps past the cutoff in a single step",
+			name:         "monthly turn rolls forward in 30-day steps",
 			virtualStart: "2025-02-10T03:00:00-08:00",
 			turn:         30 * day,
-			want:         "2026-05-06T03:00:00-08:00",
+			wantStart:    "2026-05-06T03:00:00-08:00",
+			wantOffset:   15,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := rollVirtualStartForward(mustParse(tc.virtualStart), tc.turn, now)
-			if !got.Equal(mustParse(tc.want)) {
-				t.Fatalf("got %s, want %s", got.Format(time.RFC3339), tc.want)
+			gotStart, gotOffset := rollVirtualStartForward(mustParse(tc.virtualStart), tc.turn, now)
+			if !gotStart.Equal(mustParse(tc.wantStart)) {
+				t.Errorf("start: got %s, want %s", gotStart.Format(time.RFC3339), tc.wantStart)
 			}
-			cutoff := now.Add(-fhStartTimeWindow)
-			if tc.turn > 0 && got.Before(cutoff) && !got.Equal(mustParse(tc.virtualStart)) {
-				t.Fatalf("rolled value %s is still before cutoff %s", got, cutoff)
+			if gotOffset != tc.wantOffset {
+				t.Errorf("offset: got %d, want %d", gotOffset, tc.wantOffset)
 			}
 		})
 	}


### PR DESCRIPTION
## BLUF

When a PagerDuty schedule layer's `rotation_virtual_start` falls in the past — even by a single rotation cycle — the migrated FireHydrant rotation puts the **wrong user** on call. 

## Root cause

FireHydrant's rotation scheduler (`base_scheduler.rb:92-101`) advances time **without rotating the cursor** when a cycle window has no generatable shifts — for example, when every restriction window in that cycle is in the past at schedule-creation time. The migrator was emitting PD's `rotation_virtual_start` as-is whenever it sat within FH's 25-day acceptance window. So for a weekly rotation created 8 days after `virtual_start`:

- PD: 1 full week has elapsed → cursor advances to user index 1.
- FH: first cycle's restrictions are all in the past → empty-window branch skips them, leaves cursor at user index 0.
- Result: FH is one cursor position behind PD, indefinitely.

This is distinct from #223's "FH rejects start_time > 1 month old" fix — that one only kicks in for `virtual_start` older than ~25 days. The empty-window drift bites *any* past virtual_start, even by minutes-past-a-handoff.

## Fix

`rollVirtualStartForward` (in `pager/pagerduty.go`) now:

1. Always rolls `virtual_start` forward by whole turn cycles to land on the **most recent cycle boundary at-or-before `now`**. This guarantees no empty cycles between the emitted `start_time` and schedule-creation time.
2. Returns the number of cycles advanced as a second return value.

`saveLayerToDB` uses the returned offset to **rotate the layer's user list by that many positions** before inserting members, so PagerDuty's currently-on-call user lands at FireHydrant's index 0. From there, FH's normal cycle-by-cycle advance walks through the (already-rotated) list in step with PD.

```go
elapsed := now.Sub(virtualStart)
cycles  := int(elapsed / turn)
newVS   := virtualStart.Add(time.Duration(cycles) * turn)
// caller: users = users[cycles % len(users):] + users[:cycles % len(users)]
```

The previously-introduced `fhStartTimeWindow = 25 * 24 * time.Hour` constant is removed; the new algorithm's "always within one turn of now" is strictly tighter than the old 25-day window for any turn ≤ 25 days, which covers every sane PD rotation.

