### PR TITLE
Pin the clock in PagerDuty tests to stop member-order expectations drifting

### DIFF
--- a/pager/pagerduty.go
+++ b/pager/pagerduty.go
@@ -17,6 +17,7 @@ import (
 
 type PagerDuty struct {
 	client *pagerduty.Client
+	now    func() time.Time
 }
 
 var (
@@ -28,13 +29,23 @@ var (
 func NewPagerDuty(apiKey string) *PagerDuty {
 	return &PagerDuty{
 		client: pagerduty.NewClient(apiKey),
+		now:    time.Now,
 	}
 }
 
 func NewPagerDutyWithURL(apiKey, url string) *PagerDuty {
 	return &PagerDuty{
 		client: pagerduty.NewClient(apiKey, pagerduty.WithAPIEndpoint(url)),
+		now:    time.Now,
 	}
+}
+
+// SetNow overrides the clock used to anchor rotations and filter ended
+// layers. Member ordering depends on how many rotation cycles have elapsed
+// between a layer's virtual start and now, so tests pin this to a fixed
+// instant to keep order expectations deterministic.
+func (p *PagerDuty) SetNow(now func() time.Time) {
+	p.now = now
 }
 
 func (p *PagerDuty) Kind() string {
@@ -375,7 +386,7 @@ func (p *PagerDuty) saveScheduleToDB(ctx context.Context, schedule pagerduty.Sch
 	// Create rotation records under the parent schedule (each layer becomes a rotation).
 	// PagerDuty keeps ended/replaced layers in the schedule_layers response with a non-null
 	// `end` timestamp. Skip those so they don't show up as extra FireHydrant rotations.
-	now := time.Now()
+	now := p.now()
 	order := 0
 	for _, layer := range schedule.ScheduleLayers {
 		if layer.End != "" {
@@ -441,7 +452,7 @@ func (p *PagerDuty) saveLayerToDB(ctx context.Context, scheduleID string, layer 
 		// of cycles advanced — we use it below to rotate the member list so
 		// PagerDuty's currently-on-call user lands at index 0 in FireHydrant.
 		var rolled time.Time
-		rolled, cursorOffset = rollVirtualStartForward(virtualStart, turn, time.Now())
+		rolled, cursorOffset = rollVirtualStartForward(virtualStart, turn, p.now())
 		rotationParams.StartTime = rolled.Format(time.RFC3339)
 	} else {
 		console.Errorf("unable to parse virtual start time '%v', assuming default values", layer.RotationVirtualStart)

--- a/pager/pagerduty_test.go
+++ b/pager/pagerduty_test.go
@@ -23,11 +23,20 @@ func TestPagerDuty(t *testing.T) {
 	// Asserting the content of database is a little tricky. As such, we encode the data into JSON and compare it
 	// with the expected JSON in ./testdata/TestPagerDuty/[TestName].golden.json for each test case.
 
+	// Rotation anchoring (and therefore member order) depends on how many
+	// rotation cycles have elapsed between each fixture layer's virtual start
+	// and "now", so pin the clock — otherwise order expectations flip as real
+	// time advances past the fixtures. 2024-04-12 is shortly after the most
+	// recent fixture virtual starts (2024-04-05 / 2024-04-08), so those layers
+	// have completed zero cycles and keep their original member order.
+	pinnedNow := time.Date(2024, 4, 12, 0, 0, 0, 0, time.UTC)
+
 	// Avoid sharing setup code between tests to prevent test pollution in parallel execution.
 	setup := func(t *testing.T) (context.Context, pager.Pager) {
 		ctx := withTestDB(t)
 		ts := pagerProviderHttpServer(t)
 		pd := pager.NewPagerDutyWithURL("api-key-very-secret", ts.URL)
+		pd.SetNow(func() time.Time { return pinnedNow })
 		return ctx, pd
 	}
 
@@ -446,7 +455,7 @@ func TestPagerDuty(t *testing.T) {
 		if delta < 0 || delta%week != 0 {
 			t.Errorf("rolled value is not a non-negative multiple of one week from original: delta=%s", delta)
 		}
-		if cutoff := time.Now().Add(-26 * 24 * time.Hour); got.Before(cutoff) {
+		if cutoff := pinnedNow.Add(-26 * 24 * time.Hour); got.Before(cutoff) {
 			t.Errorf("rolled StartTime %s is older than 26 days, FireHydrant will reject it", r.StartTime)
 		}
 	})


### PR DESCRIPTION
## Why

`TestPagerDuty/LoadSchedulesPreservesMemberOrder` and `TerraformOutputMatchesScheduleOrder` fail deterministically on `main` today with no code change since they merged green (May 19–20, #226/#227). The cause is time itself: rotation anchoring rolls each layer's `virtual_start` forward relative to `time.Now()` and rotates the member list by elapsed cycles (`rollVirtualStartForward` → `rotateUsersForward`). For the two-member weekly fixture layer `PSQ0VRL` (anchored 2024-04-05), the expected member order flips **every week of real time** — the tests were correct on even weeks and wrong on odd ones.

This currently blocks #228 (and any other PR) from getting a green `test` check.

## What

- `PagerDuty` gets an injectable clock (`now func() time.Time` field, defaulting to `time.Now`, with an exported `SetNow` test hook). Both call sites (ended-layer filtering and virtual-start rolling) use it; production behavior is unchanged.
- Tests pin the clock to `2024-04-12T00:00:00Z` — shortly after the most recent fixture virtual starts, so those layers have completed zero rotation cycles and the **original, as-written member-order expectations hold permanently**. No expectation values changed, which is the evidence the pinned reference matches the test authors' intent.
- The 26-day staleness assertion compares against the same pinned reference instead of real `time.Now()`.

## Testing

- Before: the two order tests fail 3/3 locally on `main` and on this branch's parent; after: full `go test ./...` green (`pager`, `tfrender`, `diagnostics`, `internal/firehydrant`), `gofmt`/`go vet` clean.
- The failures CI shows on #228 are exactly these tests, so merging this unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)